### PR TITLE
FEAT: #1 공통 에러 및 응답 구조를 구현한다

### DIFF
--- a/src/main/java/org/zapply/product/global/apiPayload/ApiControllerAdvice.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/ApiControllerAdvice.java
@@ -1,0 +1,27 @@
+package org.zapply.product.global.apiPayload;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+import org.zapply.product.global.apiPayload.response.ApiResponse;
+
+@RestControllerAdvice
+@Log4j2
+public class ApiControllerAdvice {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("Exception : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.E500), GlobalErrorType.E500.getStatus());
+    }
+
+    @ExceptionHandler(CoreException.class)
+    public ResponseEntity<ApiResponse<?>> handleCoreException(CoreException e) {
+        log.error("CoreException : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(e.getErrorType()), e.getErrorType().getStatus());
+    }
+
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/CoreException.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/CoreException.java
@@ -1,0 +1,15 @@
+package org.zapply.product.global.apiPayload.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CoreException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    public CoreException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/ErrorMessage.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/ErrorMessage.java
@@ -1,0 +1,17 @@
+package org.zapply.product.global.apiPayload.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorMessage {
+
+    private final String code;
+
+    private final String message;
+
+    public ErrorMessage(ErrorType errorType) {
+        this.code = errorType.name();
+        this.message = errorType.getMessage();
+    }
+
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/ErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/ErrorType.java
@@ -1,0 +1,12 @@
+package org.zapply.product.global.apiPayload.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorType {
+
+    String name();
+
+    HttpStatus getStatus();
+
+    String getMessage();
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
@@ -1,0 +1,17 @@
+package org.zapply.product.global.apiPayload.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorType implements ErrorType {
+
+    E500(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/ValidationException.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/ValidationException.java
@@ -1,0 +1,26 @@
+package org.zapply.product.global.apiPayload.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import java.util.List;
+
+@Getter
+public class ValidationException implements ErrorType {
+    private final HttpStatus status = HttpStatus.BAD_REQUEST;
+    private final List<String> errors;
+
+    public ValidationException(List<String> errors) {
+        this.errors = errors;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Validation failed: " + String.join(", ", errors);
+    }
+
+    @Override
+    public String name() {
+        return "VALIDATION_ERROR";
+    }
+}
+

--- a/src/main/java/org/zapply/product/global/apiPayload/response/ApiResponse.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/response/ApiResponse.java
@@ -1,0 +1,20 @@
+package org.zapply.product.global.apiPayload.response;
+
+import org.zapply.product.global.apiPayload.exception.ErrorMessage;
+import org.zapply.product.global.apiPayload.exception.ErrorType;
+
+public record ApiResponse<T>(ResultType result, T data, ErrorMessage error) {
+
+    public static ApiResponse<?> success() {
+        return new ApiResponse<>(ResultType.SUCCESS, null, null);
+    }
+
+    public static <S> ApiResponse<S> success(S data) {
+        return new ApiResponse<>(ResultType.SUCCESS, data, null);
+    }
+
+    public static ApiResponse<?> error(ErrorType error) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error));
+    }
+
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/response/ResultType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/response/ResultType.java
@@ -1,0 +1,6 @@
+package org.zapply.product.global.apiPayload.response;
+
+public enum ResultType {
+    SUCCESS, ERROR
+}
+


### PR DESCRIPTION
## 💡 관련 이슈
> #1 

## 📝 작업 내용
- 공통 응답과 예외(에러) 응답을 추가하였습니다.
- `E500(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다.")` 와 같이 커스텀 Code를 반환할 예정이며, 추후 프론트와 상의해서 에러코드를 정하면 될 것 같습니다.
- 현재는 전역 에러(Global Error)를 (Error)500으로 정의해둔 상태입니다.


## 🧑‍💻 변경 사항
### 성공응답
![스크린샷 2025-02-26 오전 2 18 26](https://github.com/user-attachments/assets/71049fb9-186e-45b5-b3e9-fbdffb3efaab)

### 실패응답
![스크린샷 2025-02-26 오전 2 19 02](https://github.com/user-attachments/assets/15b02aaa-810d-4283-82ef-6620e516927c)

## 💬 리뷰 요구사항(선택)
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
