### PR TITLE
FEAT: 자체 회원가입, 로그인, 로그아웃, 토큰 재발급 기능을 구현한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,34 @@ repositories {
 }
 
 dependencies {
+	// spring boot
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// database
+	implementation 'org.postgresql:postgresql'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
+
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/zapply/product/ProductApplication.java
+++ b/src/main/java/org/zapply/product/ProductApplication.java
@@ -2,7 +2,9 @@ package org.zapply.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ProductApplication {
 

--- a/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
@@ -1,0 +1,65 @@
+package org.zapply.product.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.zapply.product.domain.user.dto.request.AuthRequest;
+import org.zapply.product.domain.user.dto.request.SignInRequest;
+import org.zapply.product.domain.user.dto.response.MemberResponse;
+import org.zapply.product.domain.user.dto.response.TokenResponse;
+import org.zapply.product.domain.user.service.AuthService;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+import org.zapply.product.global.apiPayload.response.ApiResponse;
+import org.zapply.product.global.security.AuthDetails;
+import org.zapply.product.global.security.jwt.JwtProvider;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    @Value("${jwt.header}")
+    private String tokenHeader;
+
+    private final AuthService authService;
+    private final JwtProvider jwtProvider;
+
+    @PostMapping("/sign-up")
+    @Operation(summary = "회원가입", description = "사용자의 정보 입력 후 회원가입")
+    public ApiResponse<MemberResponse> signUp(@Validated @RequestBody AuthRequest authRequest) {
+        return ApiResponse.success(authService.signUp(authRequest));
+    }
+
+    @PostMapping("/sign-in")
+    @Operation(summary = "로그인", description = "로그인 기능")
+    public ApiResponse<TokenResponse> signIn(@Validated @RequestBody SignInRequest signInRequest) {
+        return ApiResponse.success(authService.signIn(signInRequest));
+    }
+
+    @PostMapping("/sign-out")
+    @Operation(summary = "로그아웃", description = "로그아웃 기능")
+    public ApiResponse<?> signOut(HttpServletRequest request) {
+        String refreshToken = jwtProvider.resolveRefreshToken(request);
+        String accessToken = jwtProvider.resolveAccessToken(request);
+
+        if(refreshToken==null || accessToken==null) throw new CoreException(GlobalErrorType.TOKEN_NOT_FOUND);
+
+        authService.signOut(refreshToken, accessToken);
+        return ApiResponse.success("로그아웃 성공");
+    }
+
+    @GetMapping("/recreate")
+    @Operation(summary = "토큰 재발급", description = "AccessToken 만료 시 RefreshToken으로 AccessToken 재발급")
+    public ApiResponse<TokenResponse> recreate(HttpServletRequest request, @AuthenticationPrincipal AuthDetails authDetails) {
+        String token = request.getHeader(tokenHeader);
+        if(token ==null) throw new CoreException(GlobalErrorType.TOKEN_NOT_FOUND);
+        return ApiResponse.success(authService.recreate(token, authDetails.getUser()));
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
@@ -49,8 +49,6 @@ public class AuthController {
         String refreshToken = jwtProvider.resolveRefreshToken(request);
         String accessToken = jwtProvider.resolveAccessToken(request);
 
-        if(refreshToken==null || accessToken==null) throw new CoreException(GlobalErrorType.TOKEN_NOT_FOUND);
-
         authService.signOut(refreshToken, accessToken);
         return ApiResponse.success("로그아웃 성공");
     }
@@ -59,7 +57,6 @@ public class AuthController {
     @Operation(summary = "토큰 재발급", description = "AccessToken 만료 시 RefreshToken으로 AccessToken 재발급")
     public ApiResponse<TokenResponse> recreate(HttpServletRequest request, @AuthenticationPrincipal AuthDetails authDetails) {
         String token = request.getHeader(tokenHeader);
-        if(token ==null) throw new CoreException(GlobalErrorType.TOKEN_NOT_FOUND);
         return ApiResponse.success(authService.recreate(token, authDetails.getUser()));
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/dto/request/AuthRequest.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/request/AuthRequest.java
@@ -1,0 +1,31 @@
+package org.zapply.product.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import org.zapply.product.domain.user.entity.Credential;
+import org.zapply.product.domain.user.entity.Member;
+
+@Builder
+public record AuthRequest(
+
+        @Schema(description = "이메일", example = "zaply123@gmail.com")
+        String email,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phoneNumber,
+
+        @Schema(description = "주민등록번호", example = "123456-1234567")
+        String residentNumber,
+
+        @Schema(description = "비밀번호", example = "password123")
+        String password
+) {
+    public Member toMember(Credential credential) {
+        return Member.builder()
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .residentNumber(residentNumber)
+                .credential(credential)
+                .build();
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/dto/request/SignInRequest.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/request/SignInRequest.java
@@ -1,0 +1,15 @@
+package org.zapply.product.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record SignInRequest(
+
+        @Schema(description = "이메일", example = "zaply123@gmail.com")
+        String email,
+
+        @Schema(description = "비밀번호", example = "password123")
+        String password
+) {
+}

--- a/src/main/java/org/zapply/product/domain/user/dto/response/MemberResponse.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/response/MemberResponse.java
@@ -1,0 +1,30 @@
+package org.zapply.product.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.enumerate.MemberType;
+
+@Builder
+public record MemberResponse(
+        @Schema(description = "회원 ID", example = "1")
+        Long id,
+
+        @Schema(description = "이메일", example = "zaply@gmail.com")
+        String email,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phoneNumber,
+
+        @Schema(description = "회원 타입", example = "GENERAL | ADMIN")
+        MemberType memberType
+) {
+    public static MemberResponse of(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .phoneNumber(member.getPhoneNumber())
+                .memberType(member.getMemberType())
+                .build();
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/response/TokenResponse.java
@@ -1,0 +1,15 @@
+package org.zapply.product.domain.user.dto.response;
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/entity/Credential.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Credential.java
@@ -1,0 +1,25 @@
+package org.zapply.product.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Credential {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "bigint", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    public Credential(String hashedPassword) {
+        this.password = hashedPassword;
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/entity/Member.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Member.java
@@ -1,0 +1,55 @@
+package org.zapply.product.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.zapply.product.domain.user.enumerate.MemberType;
+import org.zapply.product.global.BaseTimeEntity;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@SQLDelete(sql = "UPDATE \"member\" SET deleted_at = NOW() WHERE id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "varchar(320)")
+    private String email;
+
+    @Column(nullable = false, columnDefinition = "varchar(20)")
+    private String phoneNumber;
+
+    @Column(nullable = false, columnDefinition = "varchar(30)")
+    private String residentNumber;
+
+    @Column(columnDefinition = "varchar(20)")
+    private String name;
+
+    @Column(columnDefinition = "varchar(20)")
+    private LocalDate birthDate;
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    @Enumerated(EnumType.STRING)
+    private MemberType memberType;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "credential_id", referencedColumnName = "id")
+    private Credential credential;
+
+    @Builder
+    public Member(String email, String phoneNumber, String residentNumber, MemberType memberType, Credential credential) {
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.residentNumber = residentNumber;
+        this.memberType = memberType != null ? memberType : MemberType.GENERAL;
+        this.credential = credential;
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/enumerate/MemberType.java
+++ b/src/main/java/org/zapply/product/domain/user/enumerate/MemberType.java
@@ -1,0 +1,12 @@
+package org.zapply.product.domain.user.enumerate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberType {
+    GENERAL("일반 사용자"),
+    ADMIN("관리자");
+
+    private final String role;
+}

--- a/src/main/java/org/zapply/product/domain/user/repository/CredentialRepository.java
+++ b/src/main/java/org/zapply/product/domain/user/repository/CredentialRepository.java
@@ -1,0 +1,7 @@
+package org.zapply.product.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zapply.product.domain.user.entity.Credential;
+
+public interface CredentialRepository extends JpaRepository<Credential, Long> {
+}

--- a/src/main/java/org/zapply/product/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/zapply/product/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.zapply.product.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zapply.product.domain.user.entity.Member;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/org/zapply/product/domain/user/service/AuthService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AuthService.java
@@ -63,6 +63,7 @@ public class AuthService {
      */
     @Transactional
     public void signOut(String refreshToken, String accessToken) {
+        if(refreshToken==null || accessToken==null) throw new CoreException(GlobalErrorType.TOKEN_NOT_FOUND);
         if(!jwtProvider.validateToken(accessToken)) {
             throw new CoreException(GlobalErrorType.TOKEN_INVALID);
         }
@@ -76,16 +77,13 @@ public class AuthService {
      * @return tokenResponse
      */
     public TokenResponse recreate(String token, Member member) {
-        if (member == null) {
-            throw new CoreException(GlobalErrorType.MEMBER_NOT_FOUND);
-        }
+        if(token ==null) throw new CoreException(GlobalErrorType.TOKEN_NOT_FOUND);
+        if (member == null) throw new CoreException(GlobalErrorType.MEMBER_NOT_FOUND);
 
         String refreshToken = token.substring(7);
         boolean isValid = jwtProvider.validateToken(refreshToken);
 
-        if (!isValid) {
-            throw new CoreException(GlobalErrorType.TOKEN_INVALID);
-        }
+        if (!isValid) throw new CoreException(GlobalErrorType.TOKEN_INVALID);
 
         String email = jwtProvider.getEmail(refreshToken);
         String redisRefreshToken = redisClient.getValue(email);

--- a/src/main/java/org/zapply/product/domain/user/service/AuthService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AuthService.java
@@ -1,0 +1,99 @@
+package org.zapply.product.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zapply.product.domain.user.dto.request.AuthRequest;
+import org.zapply.product.domain.user.dto.request.SignInRequest;
+import org.zapply.product.domain.user.dto.response.TokenResponse;
+import org.zapply.product.domain.user.dto.response.MemberResponse;
+import org.zapply.product.domain.user.entity.Credential;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+import org.zapply.product.global.redis.RedisClient;
+import org.zapply.product.global.security.jwt.JwtProvider;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserService userService;
+    private final CredentialService credentialService;
+    private final JwtProvider jwtProvider;
+    private final RedisClient redisClient;
+
+    @Value("${jwt.token.refresh-expiration-time}")
+    private long refreshTokenExpirationTime;
+
+    /**
+     * 회원가입 메서드
+     * @param authRequest
+     * @return MemberResponse
+     */
+    @Transactional
+    public MemberResponse signUp(AuthRequest authRequest) {
+        Credential credential = credentialService.createCredential(authRequest);
+        Member member = userService.createUser(credential, authRequest);
+
+        return MemberResponse.of(member);
+    }
+
+    /**
+     * 로그인 메서드
+     * @param signInRequest
+     * @return TokenResponse
+     */
+    @Transactional
+    public TokenResponse signIn(SignInRequest signInRequest) {
+        Member member = userService.getUserByEmail(signInRequest.email());
+        credentialService.checkPassword(member, signInRequest.password());
+
+        TokenResponse tokenResponse = jwtProvider.createToken(member);
+        redisClient.setValue(member.getEmail(), tokenResponse.refreshToken(), refreshTokenExpirationTime);
+
+        return tokenResponse;
+    }
+
+    /**
+     * 로그아웃 메서드
+     * @param refreshToken
+     * @param accessToken
+     */
+    @Transactional
+    public void signOut(String refreshToken, String accessToken) {
+        if(!jwtProvider.validateToken(accessToken)) {
+            throw new CoreException(GlobalErrorType.TOKEN_INVALID);
+        }
+        jwtProvider.invalidateTokens(refreshToken, accessToken);
+    }
+
+    /**
+     * 토큰 재발급 메서드
+     * @param token
+     * @param member
+     * @return tokenResponse
+     */
+    public TokenResponse recreate(String token, Member member) {
+        if (member == null) {
+            throw new CoreException(GlobalErrorType.MEMBER_NOT_FOUND);
+        }
+
+        String refreshToken = token.substring(7);
+        boolean isValid = jwtProvider.validateToken(refreshToken);
+
+        if (!isValid) {
+            throw new CoreException(GlobalErrorType.TOKEN_INVALID);
+        }
+
+        String email = jwtProvider.getEmail(refreshToken);
+        String redisRefreshToken = redisClient.getValue(email);
+
+        if (refreshToken.isEmpty() || redisRefreshToken.isEmpty() || !redisRefreshToken.equals(refreshToken)) {
+            throw new CoreException(GlobalErrorType.TOKEN_NOT_FOUND);
+        }
+
+        return jwtProvider.recreate(member, refreshToken);
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/service/AuthService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
     private final RedisClient redisClient;
 
     @Value("${jwt.token.refresh-expiration-time}")
-    private long refreshTokenExpirationTime;
+    private Long refreshTokenExpirationTime;
 
     /**
      * 회원가입 메서드

--- a/src/main/java/org/zapply/product/domain/user/service/CredentialService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/CredentialService.java
@@ -1,0 +1,47 @@
+package org.zapply.product.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.zapply.product.domain.user.dto.request.AuthRequest;
+import org.zapply.product.domain.user.entity.Credential;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.repository.CredentialRepository;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+
+@Service
+@RequiredArgsConstructor
+public class CredentialService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final CredentialRepository credentialRepository;
+
+    /**
+     * Credential을 생성하고 저장하는 메서드
+     * @param authRequest
+     * @return Credential
+     */
+    public Credential createCredential(AuthRequest authRequest) {
+
+        String hashedPassword = passwordEncoder.encode(authRequest.password());
+        Credential credential = Credential.builder()
+                .hashedPassword(hashedPassword)
+                .build();
+
+        return credentialRepository.save(credential);
+    }
+
+    /**
+     * 비밀번호를 확인하는 메서드
+     * @param member
+     * @param password
+     */
+    public void checkPassword(Member member, String password) {
+        Credential credential = member.getCredential();
+
+        if(!passwordEncoder.matches(password, credential.getPassword())) {
+            throw new CoreException(GlobalErrorType.PASSWORD_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/service/UserService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/UserService.java
@@ -1,0 +1,41 @@
+package org.zapply.product.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.zapply.product.domain.user.dto.request.AuthRequest;
+import org.zapply.product.domain.user.entity.Credential;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.repository.UserRepository;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * Credential을 생성하고 저장하는 메서드
+     * @param credential
+     * @param authRequest
+     * @return Member
+     */
+    public Member createUser(Credential credential, AuthRequest authRequest) {
+        userRepository.findByEmail(authRequest.email()).ifPresent(existingUser -> {
+           throw new CoreException(GlobalErrorType.MEMBER_ALREADY_EXISTS);
+        });
+        Member member = authRequest.toMember(credential);
+        return userRepository.save(member);
+    }
+
+    /**
+     * 이메일로 사용자를 조회하는 메서드
+     * @param email
+     * @return Member
+     */
+    public Member getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/zapply/product/global/BaseTimeEntity.java
+++ b/src/main/java/org/zapply/product/global/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package org.zapply.product.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime modifiedAt;
+
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/ApiControllerAdvice.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/ApiControllerAdvice.java
@@ -15,7 +15,7 @@ public class ApiControllerAdvice {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         log.error("Exception : {}", e.getMessage(), e);
-        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.E500), GlobalErrorType.E500.getStatus());
+        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INTERNAL_SERVER_ERROR), GlobalErrorType.INTERNAL_SERVER_ERROR.getStatus());
     }
 
     @ExceptionHandler(CoreException.class)

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
@@ -8,7 +8,21 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GlobalErrorType implements ErrorType {
 
-    E500(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
+    // Member
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰이 존재하지 않습니다."),
+    TOKEN_INVALID(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 멤버입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+
+    //Redis
+    REDIS_SET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis에 값을 저장하는 데 실패했습니다."),
+    REDIS_GET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis에서 값을 가져오는 데 실패했습니다."),
+    REDIS_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis에서 값을 삭제하는 데 실패했습니다."),
+
+    // Common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/zapply/product/global/config/RedisConfig.java
+++ b/src/main/java/org/zapply/product/global/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package org.zapply.product.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private Integer port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/org/zapply/product/global/config/SecurityConfig.java
+++ b/src/main/java/org/zapply/product/global/config/SecurityConfig.java
@@ -1,0 +1,88 @@
+package org.zapply.product.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.zapply.product.global.security.ExceptionFilter;
+import org.zapply.product.global.security.jwt.JwtAccessDeniedHandler;
+import org.zapply.product.global.security.jwt.JwtAuthenticationHandler;
+import org.zapply.product.global.security.jwt.JwtFilter;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+    private final ExceptionFilter exceptionFilter;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationHandler jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable);
+
+        http.sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));// Session 미사용
+        http.httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        http.exceptionHandling((exceptionHandling) ->
+                exceptionHandling
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+        );
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(exceptionFilter, JwtFilter.class);
+
+        http.authorizeHttpRequests((authorize) ->
+                authorize.requestMatchers( "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
+                                "/swagger-resources/**",
+                                "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/v1/auth/**","/v1/user/**").permitAll()
+                        .requestMatchers("/error/**").permitAll()
+                        .anyRequest().authenticated());
+
+        return http.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("*"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public LogoutSuccessHandler logoutSuccessHandler() {
+        return new HttpStatusReturningLogoutSuccessHandler();
+    }
+}

--- a/src/main/java/org/zapply/product/global/redis/RedisClient.java
+++ b/src/main/java/org/zapply/product/global/redis/RedisClient.java
@@ -1,0 +1,54 @@
+package org.zapply.product.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisClient {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValue(String key, String value, Long timeout) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            values.set(key, value, Duration.ofMillis(timeout));
+        } catch (Exception e) {
+            throw new CoreException(GlobalErrorType.REDIS_SET_ERROR);
+        }
+    }
+
+    public String getValue(String key) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            if (values.get(key) == null) {
+                return "";
+            }
+            return values.get(key).toString();
+        } catch (Exception e) {
+            throw new CoreException(GlobalErrorType.REDIS_GET_ERROR);
+        }
+    }
+
+    public void deleteValue(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            throw new CoreException(GlobalErrorType.REDIS_DELETE_ERROR);
+        }
+    }
+
+    public boolean checkExistsValue(String key) {
+        try {
+            return redisTemplate.hasKey(key);
+        } catch (Exception e) {
+            throw new CoreException(GlobalErrorType.REDIS_GET_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/AuthDetails.java
+++ b/src/main/java/org/zapply/product/global/security/AuthDetails.java
@@ -1,0 +1,56 @@
+package org.zapply.product.global.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.zapply.product.domain.user.entity.Member;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record AuthDetails(Member member) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add(member.getMemberType().toString());
+
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+    public Member getUser() {
+        return member;
+    }
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/AuthDetailsService.java
+++ b/src/main/java/org/zapply/product/global/security/AuthDetailsService.java
@@ -1,0 +1,27 @@
+package org.zapply.product.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.repository.UserRepository;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = userRepository.findByEmail(email).orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
+
+        return new AuthDetails(member);
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/ExceptionFilter.java
+++ b/src/main/java/org/zapply/product/global/security/ExceptionFilter.java
@@ -1,0 +1,45 @@
+package org.zapply.product.global.security;
+
+import ch.qos.logback.core.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+import org.zapply.product.global.apiPayload.response.ApiResponse;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+@Component
+@RequiredArgsConstructor
+public class ExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CoreException e) { //Todo: Error handling (Core Exception Handling)
+            setResponse(response);
+        }
+    }
+
+
+    private void setResponse(HttpServletResponse response) throws IOException{
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(GlobalErrorType.FORBIDDEN.getStatus().value());
+
+        ExecutionException error = new ExecutionException(GlobalErrorType.FORBIDDEN.getMessage(), new Throwable());
+        String errorJson = objectMapper.writeValueAsString(error);
+
+        response.getWriter().write(errorJson);
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/zapply/product/global/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package org.zapply.product.global.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException{
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/jwt/JwtAuthenticationHandler.java
+++ b/src/main/java/org/zapply/product/global/security/jwt/JwtAuthenticationHandler.java
@@ -1,0 +1,19 @@
+package org.zapply.product.global.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationHandler implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException{
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/jwt/JwtFilter.java
+++ b/src/main/java/org/zapply/product/global/security/jwt/JwtFilter.java
@@ -1,0 +1,52 @@
+package org.zapply.product.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.zapply.product.global.security.AuthDetailsService;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final AuthDetailsService authDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = getTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
+            String email = jwtProvider.getEmail(token);
+            UserDetails userDetails = authDetailsService.loadUserByUsername(email);
+
+            if (userDetails != null) {
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/jwt/JwtProvider.java
+++ b/src/main/java/org/zapply/product/global/security/jwt/JwtProvider.java
@@ -1,0 +1,130 @@
+package org.zapply.product.global.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.zapply.product.domain.user.dto.response.TokenResponse;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.global.redis.RedisClient;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+    private Key key;
+
+    @Value("${jwt.token.access-expiration-time}")
+    private long accessTokenExpirationTime;
+
+    @Value("${jwt.token.refresh-expiration-time}")
+    private long refreshTokenExpirationTime;
+
+    private final RedisClient redisClient;
+
+    @PostConstruct
+    protected void init() {
+        byte[] secretKeyBytes = Decoders.BASE64.decode(secretKey);
+        key = Keys.hmacShaKeyFor(secretKeyBytes);
+    }
+
+    public String createAccessToken(Member member) {
+        Claims claims = getClaims(member);
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenExpirationTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private String createRefreshToken(Member member) {
+        Claims claims = getClaims(member);
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenExpirationTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public TokenResponse createToken(Member member) {
+        return TokenResponse.of(
+                createAccessToken(member),
+                createRefreshToken(member)
+        );
+    }
+
+    public TokenResponse recreate(Member member, String refreshToken) {
+        String accessToken = createAccessToken(member);
+
+        if(getExpirationTime(refreshToken) <= getExpirationTime(accessToken)) {
+            refreshToken = createRefreshToken(member);
+        }
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String getEmail(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public Long getExpirationTime(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().getTime();
+    }
+
+    private Claims getClaims(Member member) {
+        return Jwts.claims().setSubject(member.getEmail());
+    }
+
+    public String resolveRefreshToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    @Transactional
+    public void invalidateTokens(String refreshToken, String accessToken) {
+        if (!validateToken(refreshToken)) {
+           //Todo: Error handling: refresh token is invalid
+        }
+        redisClient.deleteValue(getEmail(refreshToken));
+        redisClient.setValue(accessToken, "logout", getExpirationTime(accessToken));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=product


### PR DESCRIPTION
## 💡 관련 이슈
- #7 


## 📝 작업 내용
### 1. 회원가입
<img width="1429" alt="스크린샷 2025-04-27 오후 11 42 29" src="https://github.com/user-attachments/assets/551d45e0-a23b-4183-949d-b64076bcc827" />

- 이메일, 휴대번호, 주민등록번호, 패스워드 입력 시 회원가입 가능
- 다른 필드들은 필수여부나 어떤 필드들이 들어갈지 구체적으로 확정된 후에 수정하면서 넣겠습니다!
- 이미 존재하는 이메일인 경우: `MEMBER_ALREADY_EXISTS`

### 2. 로그인
<img width="1435" alt="스크린샷 2025-04-27 오후 11 45 12" src="https://github.com/user-attachments/assets/bd91d02b-8702-4dcc-ac8c-c843d2c87e54" />

- 가입한 이메일, 패스워드를 입력하여 로그인
- Redis에서 오류가 난 경우: `REDIS_SET_ERROR`
- member를 찾을 수 없는 경우: `MEMBER_NOT_FOUND`
- 비밀번호가 틀린 경우: `PASSWORD_MISMATCH`

### 3. 로그아웃
<img width="1452" alt="스크린샷 2025-04-27 오후 11 50 32" src="https://github.com/user-attachments/assets/b6fd5da3-951f-47ff-8093-cc2d45649b64" />

- Access token과 함께 요청 시 작동
- Refresh Token은 Redis에서 삭제해버려서 무효화 Access Token은 Redis에 "logout"이라고 등록하여 블랙리스트에 넣어 무효화
- 토큰이 없는 경우: `TOKEN_NOT_FOUND`
- 토큰이 유효하지 않는 경우: `TOKEN_INVALID`

### 4. 토큰 재발급
<img width="1449" alt="스크린샷 2025-04-28 오전 12 00 24" src="https://github.com/user-attachments/assets/9ce9402d-b76e-4715-9199-a1581141f4f7" />

- 토큰이 없는 경우: `TOKEN_NOT_FOUND`
- 토큰이 유효하지 않는 경우: `TOKEN_INVALID`
- member를 찾을 수 없는 경우: `MEMBER_NOT_FOUND`

## 🧑‍💻 변경 사항
작업 내용 확인해주시면 감사하겠습니당


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
