### PR TITLE
FEAT: Facebook 계정을 연동하고 Access token을 장기 토큰으로 관리한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// swagger 설정
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 

--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -1,0 +1,25 @@
+package org.zapply.product.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.zapply.product.domain.user.service.AccountService;
+import org.zapply.product.global.apiPayload.response.ApiResponse;
+import org.zapply.product.global.security.AuthDetails;
+
+@RestController
+@RequestMapping("/v1/account")
+@RequiredArgsConstructor
+public class AccountController {
+    private final AccountService accountService;
+
+    @PostMapping("/facebook/link")
+    @Operation(summary = "페이스북 계정 연동", description = "페이스북 계정 연동")
+    public ApiResponse<?> signInWithGoogle(@RequestParam("code") String code, @AuthenticationPrincipal AuthDetails authDetails) {
+        return ApiResponse.success(accountService.linkFacebook(code, authDetails.getMember()));
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
@@ -13,8 +13,6 @@ import org.zapply.product.domain.user.dto.request.SignInRequest;
 import org.zapply.product.domain.user.dto.response.MemberResponse;
 import org.zapply.product.domain.user.dto.response.TokenResponse;
 import org.zapply.product.domain.user.service.AuthService;
-import org.zapply.product.global.apiPayload.exception.CoreException;
-import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
 import org.zapply.product.global.security.AuthDetails;
 import org.zapply.product.global.security.jwt.JwtProvider;
@@ -57,6 +55,6 @@ public class AuthController {
     @Operation(summary = "토큰 재발급", description = "AccessToken 만료 시 RefreshToken으로 AccessToken 재발급")
     public ApiResponse<TokenResponse> recreate(HttpServletRequest request, @AuthenticationPrincipal AuthDetails authDetails) {
         String token = request.getHeader(tokenHeader);
-        return ApiResponse.success(authService.recreate(token, authDetails.getUser()));
+        return ApiResponse.success(authService.recreate(token, authDetails.getMember()));
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/entity/Account.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Account.java
@@ -28,16 +28,19 @@ public class Account {
     @Column
     private String tokenKey;
 
+    @Column
+    private String email;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Builder
-    public Account(String accountName, SNSType accountType, String tokenKey, Member member)
-    {
+    public Account(String accountName, SNSType accountType, String tokenKey, Member member, String email) {
         this.accountName = accountName;
         this.accountType = accountType;
         this.tokenKey = tokenKey;
         this.member = member;
+        this.email = email;
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
+++ b/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
@@ -1,0 +1,12 @@
+package org.zapply.product.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zapply.product.domain.user.entity.Account;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.enumerate.SNSType;
+
+import java.util.Optional;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+    Optional<Account> findByEmailAndAccountTypeAndMember(String email, SNSType accountType, Member member);
+}

--- a/src/main/java/org/zapply/product/domain/user/repository/MemberRepository.java
+++ b/src/main/java/org/zapply/product/domain/user/repository/MemberRepository.java
@@ -5,6 +5,6 @@ import org.zapply.product.domain.user.entity.Member;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmailAndDeletedAtIsNull(String email);
 }

--- a/src/main/java/org/zapply/product/domain/user/service/AccountService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AccountService.java
@@ -1,0 +1,89 @@
+package org.zapply.product.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.zapply.product.domain.user.entity.Account;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.enumerate.SNSType;
+import org.zapply.product.domain.user.repository.AccountRepository;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+import org.zapply.product.global.redis.RedisClient;
+import org.zapply.product.global.security.facebook.FacebookClient;
+import org.zapply.product.global.security.facebook.FacebookProfile;
+import org.zapply.product.global.security.facebook.FacebookToken;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+    private final AccountRepository accountRepository;
+    private final RedisClient redisClient;
+    private final FacebookClient facebookClient;
+
+    @Value("${spring.security.oauth2.client.registration.facebook.redirect-uri}")
+    private String facebookRedirectUrl;
+
+
+    /**
+     * 페이스북 계정 연동
+     * @param code
+     * @param member
+     * @return Redis Key
+     */
+    public String linkFacebook(String code, Member member) {
+        // 페이스북으로 액세스 토큰 요청하기
+        FacebookToken facebookAccessToken = facebookClient.getFacebookAccessToken(code, facebookRedirectUrl);
+
+        // 페이스북에 있는 사용자 정보 반환
+        FacebookProfile facebookProfile = facebookClient.getMemberInfo(facebookAccessToken);
+
+        // 반환된 정보의 이메일 추출
+        String email = facebookProfile.email();
+        if (email == null) {
+            throw new CoreException(GlobalErrorType.EMAIL_NOT_FOUND);
+        }
+
+        //bussiness logic: account 정보가 이미 있다면 확인 후 해당 account 정보를 반환하고, 없다면 새로운 account 정보를 생성하여 반환
+        Account account = accountRepository.findByEmailAndAccountTypeAndMember(email, SNSType.FACEBOOK, member)
+                .orElseGet(() -> {
+                    Account newAccount = Account.builder()
+                            .accountName(facebookProfile.name())
+                            .email(email)
+                            .accountType(SNSType.FACEBOOK)
+                            .tokenKey("facebook:" + email)
+                            .member(member)
+                            .build();
+                    return accountRepository.save(newAccount);
+                });
+
+        // redis에 페이스북 액세스 토큰 저장
+        String redisKey = "facebook:" + generateRedisKey(member.getId(), email);
+
+        // Redis에 값 저장 (72시간)
+        redisClient.setValue(redisKey, facebookAccessToken.accessToken(), 259200L);
+
+        return redisKey;
+    }
+
+    /**
+     * Redis Key 생성
+     * @param memberId
+     * @param email
+     * @return Redis Key
+     */
+    public String generateRedisKey(Long memberId, String email) {
+        try {
+            String rawKey = memberId + ":" + email;
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rawKey.getBytes());
+            return Base64.getUrlEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new CoreException(GlobalErrorType.SHA256_GENERATION_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/service/UserService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/UserService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import org.zapply.product.domain.user.dto.request.AuthRequest;
 import org.zapply.product.domain.user.entity.Credential;
 import org.zapply.product.domain.user.entity.Member;
-import org.zapply.product.domain.user.repository.UserRepository;
+import org.zapply.product.domain.user.repository.MemberRepository;
 import org.zapply.product.global.apiPayload.exception.CoreException;
 import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 
@@ -13,7 +13,7 @@ import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * Credential을 생성하고 저장하는 메서드
@@ -22,11 +22,11 @@ public class UserService {
      * @return Member
      */
     public Member createUser(Credential credential, AuthRequest authRequest) {
-        userRepository.findByEmail(authRequest.email()).ifPresent(existingUser -> {
+        memberRepository.findByEmailAndDeletedAtIsNull(authRequest.email()).ifPresent(existingUser -> {
            throw new CoreException(GlobalErrorType.MEMBER_ALREADY_EXISTS);
         });
         Member member = authRequest.toMember(credential);
-        return userRepository.save(member);
+        return memberRepository.save(member);
     }
 
     /**
@@ -35,7 +35,7 @@ public class UserService {
      * @return Member
      */
     public Member getUserByEmail(String email) {
-        return userRepository.findByEmail(email)
+        return memberRepository.findByEmailAndDeletedAtIsNull(email)
                 .orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
@@ -15,16 +15,20 @@ public enum GlobalErrorType implements ErrorType {
     MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 멤버입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
+    // Account
+    ALREADY_EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 존재하는 계정입니다."),
+    EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일이 존재하지 않습니다."),
+    FACEBOOK_API_ERROR(HttpStatus.BAD_REQUEST, "페이스북 API 호출에 실패했습니다."),
+
     //Redis
     REDIS_SET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis에 값을 저장하는 데 실패했습니다."),
     REDIS_GET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis에서 값을 가져오는 데 실패했습니다."),
     REDIS_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis에서 값을 삭제하는 데 실패했습니다."),
+    SHA256_GENERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SHA256 해시 생성에 실패했습니다."),
 
     // Common
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다."),
-    ;
-
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다.");
     private final HttpStatus status;
 
     private final String message;

--- a/src/main/java/org/zapply/product/global/config/SecurityConfig.java
+++ b/src/main/java/org/zapply/product/global/config/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig {
                         "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
                                 "/v1/api-docs/**","/v1/api-docs/swagger-config",
                                 "/swagger-resources/**",
-                                "/v3/api-docs/**").permitAll()
+                                "/v3/api-docs/**",
+                                "/v1/account/facebook/link").permitAll()
                         .requestMatchers("/v1/auth/**","/v1/user/**").permitAll()
                         .requestMatchers("/error/**").permitAll()
                         .anyRequest().authenticated());

--- a/src/main/java/org/zapply/product/global/security/AuthDetails.java
+++ b/src/main/java/org/zapply/product/global/security/AuthDetails.java
@@ -21,7 +21,7 @@ public record AuthDetails(Member member) implements UserDetails {
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }
-    public Member getUser() {
+    public Member getMember() {
         return member;
     }
     @Override

--- a/src/main/java/org/zapply/product/global/security/AuthDetailsService.java
+++ b/src/main/java/org/zapply/product/global/security/AuthDetailsService.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zapply.product.domain.user.entity.Member;
-import org.zapply.product.domain.user.repository.UserRepository;
+import org.zapply.product.domain.user.repository.MemberRepository;
 import org.zapply.product.global.apiPayload.exception.CoreException;
 import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 
@@ -16,11 +16,11 @@ import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 @RequiredArgsConstructor
 public class AuthDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = userRepository.findByEmail(email).orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
+        Member member = memberRepository.findByEmailAndDeletedAtIsNull(email).orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
 
         return new AuthDetails(member);
     }

--- a/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
+++ b/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
@@ -1,0 +1,77 @@
+package org.zapply.product.global.security.facebook;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class FacebookClient {
+
+    @Value("${spring.security.oauth2.client.registration.facebook.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.facebook.client-secret}")
+    private String clientSecret;
+
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient = RestClient.create();
+
+    /**
+     * 페이스북으로부터 받은 인가코드를 통해 액세스 토큰 요청하기
+     * @param code
+     * @param redirectUri
+     * @return FacebookToken
+     */
+    public FacebookToken getFacebookAccessToken(String code, String redirectUri) {
+        String response = restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host("graph.facebook.com")
+                        .path("/v22.0/oauth/access_token")
+                        .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", redirectUri)
+                        .queryParam("client_secret", clientSecret)
+                        .queryParam("code", code)
+                        .build())
+                .retrieve()
+                .body(String.class);
+
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response);
+            return new FacebookToken(jsonNode.get("access_token").asText());
+        } catch (IOException e) {
+            throw new CoreException(GlobalErrorType.FACEBOOK_API_ERROR);
+        }
+    }
+
+    /**
+     * 페이스북에 있는 사용자 정보 반환
+     * @param token
+     * @return FacebookProfile
+     */
+    public FacebookProfile getMemberInfo(FacebookToken token) {
+        String response = restClient.get()
+                .uri("https://graph.facebook.com/me?fields=id,name,email&access_token=" + token.accessToken())
+                .retrieve()
+                .body(String.class);
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response);
+            return new FacebookProfile(
+                    jsonNode.get("id").asText(),
+                    jsonNode.get("name").asText(),
+                    jsonNode.has("email") ? jsonNode.get("email").asText() : null
+            );
+        } catch (IOException e) {
+            throw new CoreException(GlobalErrorType.FACEBOOK_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
+++ b/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
@@ -74,4 +74,26 @@ public class FacebookClient {
             throw new CoreException(GlobalErrorType.FACEBOOK_API_ERROR);
         }
     }
+
+    public FacebookToken getLongLivedToken(String shortLivedToken) {
+        String response = restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host("graph.facebook.com")
+                        .path("/v22.0/oauth/access_token")
+                        .queryParam("grant_type", "fb_exchange_token")
+                        .queryParam("client_id", clientId)
+                        .queryParam("client_secret", clientSecret)
+                        .queryParam("fb_exchange_token", shortLivedToken)
+                        .build())
+                .retrieve()
+                .body(String.class);
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response);
+            return new FacebookToken(jsonNode.get("access_token").asText());
+        } catch (IOException e) {
+            throw new CoreException(GlobalErrorType.FACEBOOK_API_ERROR);
+        }
+    }
 }

--- a/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
+++ b/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
@@ -21,6 +21,12 @@ public class FacebookClient {
     @Value("${spring.security.oauth2.client.registration.facebook.client-secret}")
     private String clientSecret;
 
+    @Value("${spring.security.oauth2.client.registration.facebook.access-token-url}")
+    private String accessTokenUrl;
+
+    @Value("${spring.security.oauth2.client.registration.facebook.user-info-url}")
+    private String userInfoUrl;
+
     private final ObjectMapper objectMapper;
     private final RestClient restClient = RestClient.create();
 
@@ -35,7 +41,7 @@ public class FacebookClient {
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
                         .host("graph.facebook.com")
-                        .path("/v22.0/oauth/access_token")
+                        .path(accessTokenUrl)
                         .queryParam("client_id", clientId)
                         .queryParam("redirect_uri", redirectUri)
                         .queryParam("client_secret", clientSecret)
@@ -60,7 +66,7 @@ public class FacebookClient {
      */
     public FacebookProfile getMemberInfo(FacebookToken token) {
         String response = restClient.get()
-                .uri("https://graph.facebook.com/me?fields=id,name,email&access_token=" + token.accessToken())
+                .uri(userInfoUrl + token.accessToken())
                 .retrieve()
                 .body(String.class);
         try {
@@ -85,7 +91,7 @@ public class FacebookClient {
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
                         .host("graph.facebook.com")
-                        .path("/v22.0/oauth/access_token")
+                        .path(accessTokenUrl)
                         .queryParam("grant_type", "fb_exchange_token")
                         .queryParam("client_id", clientId)
                         .queryParam("client_secret", clientSecret)

--- a/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
+++ b/src/main/java/org/zapply/product/global/security/facebook/FacebookClient.java
@@ -75,6 +75,11 @@ public class FacebookClient {
         }
     }
 
+    /**
+     * 페이스북에서 받은 단기 액세스 토큰을 통해 장기 액세스 토큰 요청하기
+     * @param shortLivedToken
+     * @return FacebookToken
+     */
     public FacebookToken getLongLivedToken(String shortLivedToken) {
         String response = restClient.get()
                 .uri(uriBuilder -> uriBuilder

--- a/src/main/java/org/zapply/product/global/security/facebook/FacebookProfile.java
+++ b/src/main/java/org/zapply/product/global/security/facebook/FacebookProfile.java
@@ -1,0 +1,3 @@
+package org.zapply.product.global.security.facebook;
+
+public record FacebookProfile(String id, String name, String email) {}

--- a/src/main/java/org/zapply/product/global/security/facebook/FacebookToken.java
+++ b/src/main/java/org/zapply/product/global/security/facebook/FacebookToken.java
@@ -1,0 +1,3 @@
+package org.zapply.product.global.security.facebook;
+
+public record FacebookToken(String accessToken) {}


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요
- #11 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 페이스북 로그인 작업 
- 액세스 토큰 발급
- 사용자 정보 조회
- [액세스 토큰을 장기토큰으로 변경](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived/)


## 🧑‍💻 변경 사항
### 1. 페이스북 로그인 작업
로그인 작업시 redirect uri가 https 여야 해서 ngrok로 localhost:8080을 https 주소로 변환하여 로그인 처리하였습니다! 혹시 로컬에서 테스트해보고 싶으시다면 아래 링크 참고하시면 될 것 같습니다
https://squirmm.tistory.com/entry/ngrok-localhost%EB%A5%BC-https%EB%A1%9C-%EC%A0%91%EC%86%8D%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95

### 2. 액세스 토큰 발급
- `FacebookClient-getFacebookAccessToken`메소드에 구현해두었고, 액세스 토큰은 memberId와 계정 email을 sha256으로 암호화해서 `facebook:암호화된문자열` 의 형식으로 redis에 저장하는 방식을 사용했습니다! 저장방식은 추후에 안전한 방향을 찾아서 적용해보겠습니다.

### 3. 사용자 정보 조회
- `FacebookClient-getMemberInfo`에 구현해두었고 email 추출 용도로 만들어두었습니다!

### 4. 액세스 토큰을 장기토큰으로 변경
- `FacebookClient-getLongLivedToken`에 구현해두었고 장기토큰이 2번에서 말한 저장방식으로 최종적으로 저장되는 토큰입니다!

### 5. signInWithGoogle 컨트롤러 메소드
하나의 컨트롤러 메소드에서 위 1~4번까지의 모든 기능이 동작하도록 설계했습니다!

## 💬 리뷰 요구사항(선택)
- 혹시 제가 놓친 취약점이나 보안적 문제가 있는지 한번 더 확인해주시면 감사하겠습니다😄
- 테이블명에 `tb_`는 빼도 괜찮을 것 같은데 어떠신가요?
