### PR TITLE
FEAT: 문자를 발송하고 본인인증한다.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,9 @@ jobs:
         run: |
           mkdir -p src/main/resources
           echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION_PROPERTIES_OAUTH }}" > ./src/main/resources/application-oauth.yml
+          echo "${{ secrets.APPLICATION_PROPERTIES_CLOUD }}" > ./src/main/resources/application-cloud.yml
+          echo "${{ secrets.APPLICATION_PROPERTIES_SWAGGER }}" > ./src/main/resources/application-swagger.yml
       # 4. 도커 빌드 환경 설정 (buildx 설치)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ out/
 /src/main/generated
 
 
+/src/main/resources/application-swagger.yml
+/src/main/resources/application-cloud.yml
+/src/main/resources/application-oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
 	// swagger 설정
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// coolSMS
+	implementation 'net.nurigo:sdk:4.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/zapply/product/domain/posting/entity/Image.java
+++ b/src/main/java/org/zapply/product/domain/posting/entity/Image.java
@@ -6,7 +6,6 @@ import org.zapply.product.global.BaseTimeEntity;
 
 @Getter
 @Entity
-@Table(name = "tb_image")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Image extends BaseTimeEntity {
 

--- a/src/main/java/org/zapply/product/domain/posting/entity/Posting.java
+++ b/src/main/java/org/zapply/product/domain/posting/entity/Posting.java
@@ -9,7 +9,6 @@ import org.zapply.product.domain.user.enumerate.SNSType;
 
 @Getter
 @Entity
-@Table(name = "tb_posting")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Posting extends BaseTimeEntity {
 

--- a/src/main/java/org/zapply/product/domain/project/entity/Project.java
+++ b/src/main/java/org/zapply/product/domain/project/entity/Project.java
@@ -10,7 +10,6 @@ import org.zapply.product.global.BaseTimeEntity;
 
 @Getter
 @Entity
-@Table(name = "tb_project")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Project extends BaseTimeEntity {
 

--- a/src/main/java/org/zapply/product/domain/user/controller/SmsController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/SmsController.java
@@ -1,0 +1,32 @@
+package org.zapply.product.domain.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zapply.product.domain.user.dto.request.CertificateRequest;
+import org.zapply.product.domain.user.dto.request.SmsRequest;
+import org.zapply.product.domain.user.service.SmsService;
+import org.zapply.product.global.apiPayload.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/sms")
+public class SmsController {
+
+    private final SmsService smsService;
+
+    @PostMapping("/send")
+    public ApiResponse<?> SendSMS(@RequestBody @Valid SmsRequest smsRequest){
+        smsService.SendSms(smsRequest);
+        return ApiResponse.success();
+    }
+
+    @PostMapping("/certification")
+    public ApiResponse<String> certification(@RequestBody @Valid CertificateRequest certificateRequest){
+        return ApiResponse.success(smsService.certificate(certificateRequest));
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/dto/request/CertificateRequest.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/request/CertificateRequest.java
@@ -1,0 +1,11 @@
+package org.zapply.product.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record CertificateRequest (
+        @NotEmpty(message = "휴대폰 번호를 입력해주세요")
+        String phoneNum,
+
+        @NotEmpty(message = "인증 번호를 입력해주세요")
+        String authNum
+){ }

--- a/src/main/java/org/zapply/product/domain/user/dto/request/SmsRequest.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/request/SmsRequest.java
@@ -1,0 +1,8 @@
+package org.zapply.product.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record SmsRequest(
+        @NotEmpty(message = "휴대폰 번호를 입력해주세요")
+        String phoneNum
+) { }

--- a/src/main/java/org/zapply/product/domain/user/entity/Account.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Account.java
@@ -9,7 +9,6 @@ import org.zapply.product.domain.user.enumerate.SNSType;
 
 @Getter
 @Entity
-@Table(name = "tb_account")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Account {
 

--- a/src/main/java/org/zapply/product/domain/user/entity/Member.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Member.java
@@ -37,7 +37,8 @@ public class Member extends BaseTimeEntity {
     private Credential credential;
 
     @Builder
-    public Member(String email, String phoneNumber, String residentNumber, Credential credential) {
+    public Member(String name, String email, String phoneNumber, String residentNumber, Credential credential) {
+        this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
         this.residentNumber = residentNumber;

--- a/src/main/java/org/zapply/product/domain/user/service/SmsService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/SmsService.java
@@ -18,15 +18,18 @@ public class SmsService{
     private final SMSClient smsClient;
     private final RedisClient redisClient;
 
+    // OTP 유효시간 5분
+    private static final long OTP_EXPIRATION_MILLIS = 5 * 60_000L;
     private static final SecureRandom secureRandom = new SecureRandom();
+
 
     public void SendSms(SmsRequest smsRequestDto) {
         String phoneNum = smsRequestDto.phoneNum();
 
         String certificationCode = String.format("%06d", secureRandom.nextInt(1000000));
 
-        smsClient.sendSMS(phoneNum, certificationCode); // SMS 인증 유틸리티를 사용하여 SMS 발송
-        redisClient.setValue(phoneNum, certificationCode,60000L * 5);
+        smsClient.sendSMS(phoneNum, certificationCode);
+        redisClient.setValue(phoneNum, certificationCode,OTP_EXPIRATION_MILLIS);
     }
 
     public String certificate(CertificateRequest certificateRequest) {

--- a/src/main/java/org/zapply/product/domain/user/service/SmsService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/SmsService.java
@@ -9,6 +9,8 @@ import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 import org.zapply.product.global.coolSMS.SMSClient;
 import org.zapply.product.global.redis.RedisClient;
 
+import java.security.SecureRandom;
+
 @Service
 @RequiredArgsConstructor
 public class SmsService{
@@ -16,9 +18,13 @@ public class SmsService{
     private final SMSClient smsClient;
     private final RedisClient redisClient;
 
+    private static final SecureRandom secureRandom = new SecureRandom();
+
     public void SendSms(SmsRequest smsRequestDto) {
         String phoneNum = smsRequestDto.phoneNum();
-        String certificationCode = Integer.toString((int)(Math.random() * (999999 - 100000 + 1)) + 100000); // 6자리 인증 코드를 랜덤으로 생성
+
+        String certificationCode = String.format("%06d", secureRandom.nextInt(1000000));
+
         smsClient.sendSMS(phoneNum, certificationCode); // SMS 인증 유틸리티를 사용하여 SMS 발송
         redisClient.setValue(phoneNum, certificationCode,60000L * 5);
     }

--- a/src/main/java/org/zapply/product/domain/user/service/SmsService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/SmsService.java
@@ -1,0 +1,36 @@
+package org.zapply.product.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.zapply.product.domain.user.dto.request.CertificateRequest;
+import org.zapply.product.domain.user.dto.request.SmsRequest;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+import org.zapply.product.global.coolSMS.SMSClient;
+import org.zapply.product.global.redis.RedisClient;
+
+@Service
+@RequiredArgsConstructor
+public class SmsService{
+
+    private final SMSClient smsClient;
+    private final RedisClient redisClient;
+
+    public void SendSms(SmsRequest smsRequestDto) {
+        String phoneNum = smsRequestDto.phoneNum();
+        String certificationCode = Integer.toString((int)(Math.random() * (999999 - 100000 + 1)) + 100000); // 6자리 인증 코드를 랜덤으로 생성
+        smsClient.sendSMS(phoneNum, certificationCode); // SMS 인증 유틸리티를 사용하여 SMS 발송
+        redisClient.setValue(phoneNum, certificationCode,60000L * 5);
+    }
+
+    public String certificate(CertificateRequest certificateRequest) {
+        String phoneNum = certificateRequest.phoneNum();
+        if (redisClient.getValue(phoneNum).equals(certificateRequest.authNum())){
+            redisClient.deleteValue(phoneNum);
+            return "휴대폰 인증 성공";
+        }
+        else{
+            throw new CoreException(GlobalErrorType.SMS_UNAUTHENTICATED);
+        }
+    }
+}

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
@@ -29,7 +29,11 @@ public enum GlobalErrorType implements ErrorType {
     // Common
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+
+    // CoolSMS
+    SMS_UNAUTHENTICATED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호가 일치하지 않습니다."),
+    ;
     private final HttpStatus status;
 
     private final String message;

--- a/src/main/java/org/zapply/product/global/config/SecurityConfig.java
+++ b/src/main/java/org/zapply/product/global/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((authorize) ->
                 authorize.requestMatchers(
+                        "/v1/sms/**",
                                 "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
                                 "/v1/api-docs/**", "/v1/api-docs/swagger-config",
                                 "/swagger-resources/**",

--- a/src/main/java/org/zapply/product/global/coolSMS/SMSClient.java
+++ b/src/main/java/org/zapply/product/global/coolSMS/SMSClient.java
@@ -1,0 +1,39 @@
+package org.zapply.product.global.coolSMS;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SMSClient {
+
+    @Value("${cloud.ncp.sms.api-key}") // coolsms의 API 키 주입
+    private String apiKey;
+
+    @Value("${cloud.ncp.sms.api-secret}") // coolsms의 API 비밀키 주입
+    private String apiSecret;
+
+    @Value("${cloud.ncp.sms.sender-number}") // 발신자 번호 주입
+    private String fromNumber;
+
+    DefaultMessageService messageService; // 메시지 서비스를 위한 객체
+
+    @PostConstruct // 의존성 주입이 완료된 후 초기화를 수행하는 메서드
+    public void init(){
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr"); // 메시지 서비스 초기화
+    }
+
+    // 단일 메시지 발송
+    public void sendSMS(String to, String certificationCode){
+        Message message = new Message(); // 새 메시지 객체 생성
+        message.setFrom(fromNumber); // 발신자 번호 설정
+        message.setTo(to); // 수신자 번호 설정
+        message.setText("[Zaply] 본인확인 인증번호는 " + certificationCode + "입니다."); // 메시지 내용 설정
+
+        this.messageService.sendOne(new SingleMessageSendingRequest(message)); // 메시지 발송 요청
+    }
+}

--- a/src/main/java/org/zapply/product/global/coolSMS/SMSClient.java
+++ b/src/main/java/org/zapply/product/global/coolSMS/SMSClient.java
@@ -20,6 +20,8 @@ public class SMSClient {
     @Value("${cloud.ncp.sms.sender-number}") // 발신자 번호 주입
     private String fromNumber;
 
+    private static final String MESSAGE_TEMPLATE = "[Zaply] 본인확인 인증번호는 %s입니다.";
+
     DefaultMessageService messageService; // 메시지 서비스를 위한 객체
 
     @PostConstruct // 의존성 주입이 완료된 후 초기화를 수행하는 메서드
@@ -32,7 +34,9 @@ public class SMSClient {
         Message message = new Message(); // 새 메시지 객체 생성
         message.setFrom(fromNumber); // 발신자 번호 설정
         message.setTo(to); // 수신자 번호 설정
-        message.setText("[Zaply] 본인확인 인증번호는 " + certificationCode + "입니다."); // 메시지 내용 설정
+
+        String text = String.format(MESSAGE_TEMPLATE, certificationCode);
+        message.setText(text);
 
         this.messageService.sendOne(new SingleMessageSendingRequest(message)); // 메시지 발송 요청
     }


### PR DESCRIPTION
## 💡 관련 이슈
- #26 

## 📝 작업 내용
<img width="667" alt="스크린샷 2025-05-04 오전 4 09 18" src="https://github.com/user-attachments/assets/257f4898-8b0b-4153-93a1-e537e34e306d" />

- Naver Sens는 사업자 등록증이 있어야 사용 가능해서 CoolSMS 서비스를 통해 기능 구현하였습니다.
- 문자 발송 기능 구현
- 본인 인증 기능 구현

## 🧑‍💻 변경 사항
- member 엔티티 빌더에 name 필드 추가하였습니다.