### PR TITLE
#35 Fix: 스프링 시큐리티 필터에서 문자 인증을 제외한다.

### DIFF
--- a/src/main/java/org/zapply/product/global/config/SecurityConfig.java
+++ b/src/main/java/org/zapply/product/global/config/SecurityConfig.java
@@ -89,6 +89,11 @@ public class SecurityConfig {
                                 "/v1/account/facebook/link"
                         ).permitAll()
 
+                        // 문자 인증
+                        .requestMatchers(
+                                "/v1/sms/**"
+                        ).permitAll()
+
                         // LoadBalancer용 헬스 체크
                         .requestMatchers(HttpMethod.GET,"/v1/healthcheck").permitAll()
                         .requestMatchers("/v1/auth/**","/v1/user/**").permitAll()


### PR DESCRIPTION
## 💡 관련 이슈
- #35 

## 📝 작업 내용
- 스프링 필터에서 문자인증 관련 엔드포인트르 제외했습니다

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
