### PR TITLE
FEAT: Hashicorp vault에 토큰을 암호화하여 저장한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,15 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url "https://repo.spring.io/release" }
 }
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+	}
+}
+
 
 dependencies {
 	// spring boot
@@ -61,6 +69,10 @@ dependencies {
 
 	// coolSMS
 	implementation 'net.nurigo:sdk:4.3.0'
+
+	// hashicorp vault
+	implementation 'org.springframework.cloud:spring-cloud-starter-vault-config'
+	implementation 'org.springframework.vault:spring-vault-core'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -26,10 +26,4 @@ public class AccountController {
     public ApiResponse<?> signInWithThreads(@RequestParam("code") String code, @AuthenticationPrincipal AuthDetails authDetails) {
         return ApiResponse.success(accountService.linkThreads(code, authDetails.getMember()));
     }
-
-    @GetMapping("/token")
-    @Operation(summary = "사용자의 액세스 토큰 조회", description = "토큰 조회")
-    public ApiResponse<?> getToken(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam("accountType") SNSType accountType) {
-        return ApiResponse.success(accountService.getAccessToken(authDetails.getMember(), accountType));
-    }
 }

--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -3,10 +3,8 @@ package org.zapply.product.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.zapply.product.domain.user.enumerate.SNSType;
 import org.zapply.product.domain.user.service.AccountService;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
 import org.zapply.product.global.security.AuthDetails;
@@ -27,5 +25,11 @@ public class AccountController {
     @Operation(summary = "스레드 계정 연동", description = "스레드 계정 연동")
     public ApiResponse<?> signInWithThreads(@RequestParam("code") String code, @AuthenticationPrincipal AuthDetails authDetails) {
         return ApiResponse.success(accountService.linkThreads(code, authDetails.getMember()));
+    }
+
+    @GetMapping("/token")
+    @Operation(summary = "사용자의 액세스 토큰 조회", description = "토큰 조회")
+    public ApiResponse<?> getToken(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam("accountType") SNSType accountType) {
+        return ApiResponse.success(accountService.getAccessToken(authDetails.getMember(), accountType));
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/entity/Account.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Account.java
@@ -39,14 +39,19 @@ public class Account {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Column
+    private String userId;
+
     @Builder
-    public Account(String accountName, SNSType accountType, String tokenKey, Member member, String email, LocalDateTime tokenExpireAt) {
+    public Account(String accountName, SNSType accountType, String tokenKey, Member member, String email,
+                   LocalDateTime tokenExpireAt, String userId) {
         this.accountName = accountName;
         this.accountType = accountType;
         this.tokenKey = tokenKey;
         this.member = member;
         this.email = email;
         this.tokenExpireAt = tokenExpireAt;
+        this.userId = userId;
     }
 
     public void updateTokenExpireAt(LocalDateTime tokenExpireAt) {

--- a/src/main/java/org/zapply/product/domain/user/entity/Account.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Account.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.zapply.product.domain.user.enumerate.SNSType;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,16 +32,24 @@ public class Account {
     @Column
     private String email;
 
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime tokenExpireAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Builder
-    public Account(String accountName, SNSType accountType, String tokenKey, Member member, String email) {
+    public Account(String accountName, SNSType accountType, String tokenKey, Member member, String email, LocalDateTime tokenExpireAt) {
         this.accountName = accountName;
         this.accountType = accountType;
         this.tokenKey = tokenKey;
         this.member = member;
         this.email = email;
+        this.tokenExpireAt = tokenExpireAt;
+    }
+
+    public void updateTokenExpireAt(LocalDateTime tokenExpireAt) {
+        this.tokenExpireAt = tokenExpireAt;
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
+++ b/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
@@ -1,6 +1,8 @@
 package org.zapply.product.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.zapply.product.domain.user.entity.Account;
 import org.zapply.product.domain.user.entity.Member;
 import org.zapply.product.domain.user.enumerate.SNSType;
@@ -10,4 +12,7 @@ import java.util.Optional;
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByEmailAndAccountTypeAndMember(String email, SNSType accountType, Member member);
     Optional<Account> findByAccountNameAndAccountTypeAndMember(String accountName, SNSType accountType, Member member);
+    @Query("SELECT a.tokenKey FROM Account a WHERE a.accountType = :accountType AND a.member = :member")
+    String findTokenKeyByAccountTypeAndMember(@Param("accountType") SNSType accountType,
+                                              @Param("member") Member member);
 }

--- a/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
+++ b/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
@@ -1,7 +1,6 @@
 package org.zapply.product.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.zapply.product.domain.user.entity.Account;
 import org.zapply.product.domain.user.entity.Member;
@@ -12,7 +11,6 @@ import java.util.Optional;
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByEmailAndAccountTypeAndMember(String email, SNSType accountType, Member member);
     Optional<Account> findByAccountNameAndAccountTypeAndMember(String accountName, SNSType accountType, Member member);
-    @Query("SELECT a.tokenKey FROM Account a WHERE a.accountType = :accountType AND a.member = :member")
-    String findTokenKeyByAccountTypeAndMember(@Param("accountType") SNSType accountType,
+    Optional<Account> findByAccountTypeAndMember(@Param("accountType") SNSType accountType,
                                               @Param("member") Member member);
 }

--- a/src/main/java/org/zapply/product/domain/user/service/AccountService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AccountService.java
@@ -87,6 +87,7 @@ public class AccountService {
                             .tokenKey(key)
                             .member(member)
                             .tokenExpireAt(LocalDateTime.now().plusDays(60))
+                            .userId(facebookProfile.id())
                             .build();
                     Account savedAccount = accountRepository.save(newAccount);
                     // 새 계정을 Vault에 저장
@@ -135,6 +136,7 @@ public class AccountService {
                             .tokenKey(key)
                             .member(member)
                             .tokenExpireAt(LocalDateTime.now().plusDays(60))
+                            .userId(profile.id())
                             .build();
                     Account savedAccount = accountRepository.save(newAccount);
                     // Vault에 토큰 저장

--- a/src/main/java/org/zapply/product/domain/user/service/AccountService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AccountService.java
@@ -10,13 +10,13 @@ import org.zapply.product.domain.user.enumerate.SNSType;
 import org.zapply.product.domain.user.repository.AccountRepository;
 import org.zapply.product.global.apiPayload.exception.CoreException;
 import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
-import org.zapply.product.global.redis.RedisClient;
 import org.zapply.product.global.security.facebook.FacebookClient;
 import org.zapply.product.global.security.facebook.FacebookProfile;
 import org.zapply.product.global.security.facebook.FacebookToken;
 import org.zapply.product.global.security.threads.ThreadsClient;
 import org.zapply.product.global.security.threads.ThreadsProfile;
 import org.zapply.product.global.security.threads.ThreadsToken;
+import org.zapply.product.global.vault.VaultClient;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -27,9 +27,9 @@ import java.util.Base64;
 @RequiredArgsConstructor
 public class AccountService {
     private final AccountRepository accountRepository;
-    private final RedisClient redisClient;
     private final FacebookClient facebookClient;
     private final ThreadsClient threadsClient;
+    private final VaultClient vaultClient;
 
     @Value("${spring.security.oauth2.client.registration.facebook.redirect-uri}")
     private String facebookRedirectUrl;
@@ -37,9 +37,16 @@ public class AccountService {
     @Value("${spring.security.oauth2.client.registration.threads.redirect-uri}")
     private String threadsRedirectUrl;
 
+    @Value("${spring.cloud.vault.facebook-path}")
+    private String facebookPath;
+
+    @Value("${spring.cloud.vault.threads-path}")
+    private String threadsPath;
+
 
     /**
      * 페이스북 계정 연동
+     *
      * @param code
      * @param member
      * @return Redis Key
@@ -58,8 +65,8 @@ public class AccountService {
             throw new CoreException(GlobalErrorType.EMAIL_NOT_FOUND);
         }
 
-        // rediskey 생성
-        String redisKey = "facebook:" + generateRedisKey(member.getId(), email);
+        // key 생성
+        String key = "facebook:" + "client:" + generateKey(member.getId(), email);
 
         //bussiness logic: account 정보가 이미 있다면 확인 후 해당 account 정보를 반환하고, 없다면 새로운 account 정보를 생성하여 반환
         Account account = accountRepository.findByEmailAndAccountTypeAndMember(email, SNSType.FACEBOOK, member)
@@ -68,25 +75,26 @@ public class AccountService {
                             .accountName(facebookProfile.name())
                             .email(email)
                             .accountType(SNSType.FACEBOOK)
-                            .tokenKey(redisKey)
+                            .tokenKey(key)
                             .member(member)
                             .build();
                     return accountRepository.save(newAccount);
                 });
 
-        // Redis에 값 저장 (60일동안 유지)
-        redisClient.setValue(redisKey, longFacebookAccessToken.accessToken(), 5184000L);
+        // Vault에 값 저장 (60일동안 유지)
+        vaultClient.saveSecret(facebookPath, key, longFacebookAccessToken.accessToken());
 
-        return redisKey;
+        return key;
     }
 
     /**
      * 스레드 계정 연동
+     *
      * @param code
      * @param member
      * @return Redis Key
      */
-    public String linkThreads(String code, Member member){
+    public String linkThreads(String code, Member member) {
         // 스레드로 액세스 토큰 요청하기
         ThreadsToken shortThreadsToken = threadsClient.getThreadsAccessToken(code, threadsRedirectUrl);
 
@@ -96,8 +104,8 @@ public class AccountService {
         // 스레드에 있는 사용자 정보 반환
         ThreadsProfile profile = threadsClient.getThreadsProfile(longThreadsToken.accessToken());
 
-        // 반환된 정보의 username 추출, redis key 생성
-        String redisKey = "threads:" + generateRedisKey(member.getId(), profile.username());
+        // 반환된 정보의 username 추출, key 생성
+        String key = "threads:" + "client:" + generateKey(member.getId(), profile.username());
 
         //bussiness logic: account 정보가 이미 있다면 확인 후 해당 account 정보를 반환하고, 없다면 새로운 account 정보를 생성하여 반환
         Account account = accountRepository.findByAccountNameAndAccountTypeAndMember(profile.username(), SNSType.THREADS, member)
@@ -106,24 +114,25 @@ public class AccountService {
                             .accountName(profile.username())
                             .email("")
                             .accountType(SNSType.THREADS)
-                            .tokenKey(redisKey)
+                            .tokenKey(key)
                             .member(member)
                             .build();
                     return accountRepository.save(newAccount);
                 });
 
-        // Redis에 값 저장 (60일동안 유지)
-        redisClient.setValue(redisKey, longThreadsToken.accessToken(), 5184000L);
-        return redisKey;
+        // Vault에 값 저장 (60일동안 유지)
+        vaultClient.saveSecret(threadsPath, key, longThreadsToken.accessToken());
+        return key;
     }
 
     /**
      * Redis Key 생성
+     *
      * @param memberId
      * @param email
      * @return Redis Key
      */
-    public String generateRedisKey(Long memberId, String email) {
+    public String generateKey(Long memberId, String email) {
         try {
             String rawKey = memberId + ":" + email;
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
@@ -132,5 +141,33 @@ public class AccountService {
         } catch (NoSuchAlgorithmException e) {
             throw new CoreException(GlobalErrorType.SHA256_GENERATION_ERROR);
         }
+    }
+
+    /**
+     * 사용자의 Vault에 저장된 액세스 토큰을 가져옴
+     *
+     * @param member
+     * @param accountType
+     * @return 액세스 토큰
+     */
+    public String getAccessToken(Member member, SNSType accountType) {
+        String tokenKey = accountRepository.findTokenKeyByAccountTypeAndMember(accountType, member);
+        if (tokenKey == null || tokenKey.isBlank()) {
+            throw new CoreException(GlobalErrorType.ACCOUNT_TOKEN_KEY_NOT_FOUND);
+        }
+
+        String vaultPath;
+        switch (accountType) {
+            case FACEBOOK -> vaultPath = facebookPath;
+            case THREADS -> vaultPath = threadsPath;
+            default -> throw new CoreException(GlobalErrorType.SNS_TYPE_NOT_FOUND);
+        }
+
+        String accessToken = vaultClient.getSecret(vaultPath, tokenKey);
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new CoreException(GlobalErrorType.VAULT_TOKEN_NOT_FOUND);
+        }
+
+        return accessToken;
     }
 }

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
@@ -20,6 +20,8 @@ public enum GlobalErrorType implements ErrorType {
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일이 존재하지 않습니다."),
     FACEBOOK_API_ERROR(HttpStatus.BAD_REQUEST, "페이스북 API 호출에 실패했습니다."),
     THREADS_API_ERROR(HttpStatus.BAD_REQUEST, "스레드 API 호출에 실패했습니다."),
+    ACCOUNT_TOKEN_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "계정의 토큰 키를 찾을 수 없습니다."),
+    SNS_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 SNS 타입입니다."),
 
     //Redis
     REDIS_SET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis에 값을 저장하는 데 실패했습니다."),
@@ -37,7 +39,10 @@ public enum GlobalErrorType implements ErrorType {
     OAUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "로그인 중 오류가 발생했습니다."),
 
     // CoolSMS
-    SMS_UNAUTHENTICATED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호가 일치하지 않습니다.");
+    SMS_UNAUTHENTICATED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호가 일치하지 않습니다."),
+
+    // Vault
+    VAULT_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Vault에 토큰이 존재하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/zapply/product/global/security/jasypt/JasyptStringEncryptor.java
+++ b/src/main/java/org/zapply/product/global/security/jasypt/JasyptStringEncryptor.java
@@ -4,7 +4,9 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import org.jasypt.util.text.AES256TextEncryptor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+@Component
 @Converter
 public class JasyptStringEncryptor implements AttributeConverter<String, String> {
 
@@ -23,5 +25,13 @@ public class JasyptStringEncryptor implements AttributeConverter<String, String>
     @Override
     public String convertToEntityAttribute(String dbData) {
         return encryptor.decrypt(dbData);
+    }
+
+    public String encrypt(String plainText) {
+        return encryptor.encrypt(plainText);
+    }
+
+    public String decrypt(String cipherText) {
+        return encryptor.decrypt(cipherText);
     }
 }

--- a/src/main/java/org/zapply/product/global/threads/ThreadsReplyClient.java
+++ b/src/main/java/org/zapply/product/global/threads/ThreadsReplyClient.java
@@ -1,0 +1,4 @@
+package org.zapply.product.global.threads;
+
+public class ThreadsReplyClient {
+}

--- a/src/main/java/org/zapply/product/global/vault/VaultClient.java
+++ b/src/main/java/org/zapply/product/global/vault/VaultClient.java
@@ -1,0 +1,58 @@
+package org.zapply.product.global.vault;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.VaultResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class VaultClient {
+
+    private final VaultTemplate vaultTemplate;
+    private final ObjectMapper objectMapper;
+
+
+    /**
+     * Vault에 시크릿을 저장
+     * @param path
+     * @param key
+     * @param value
+     */
+    public void saveSecret(String path, String key, String value) {
+        Map<String, Object> data = new HashMap<>();
+        data.put(key, value);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("data", data);
+
+        String fullPath = "secret/data/" + path;
+        vaultTemplate.write(fullPath, payload);
+    }
+
+    /**
+     * Vault에서 시크릿을 가져옴
+     * @param path
+     * @param key
+     * @return secret
+     */
+    public String getSecret(String path, String key) {
+        String fullPath = "secret/data/" + path;
+        VaultResponse response = vaultTemplate.read(fullPath);
+
+        if (response == null || response.getData() == null) {
+            return null;
+        }
+
+        JsonNode root = objectMapper.valueToTree(response.getData());
+        JsonNode dataNode = root.path("data");
+        JsonNode valueNode = dataNode.path(key);
+
+        return valueNode.isMissingNode() ? null : valueNode.asText();
+    }
+}

--- a/src/main/java/org/zapply/product/global/vault/VaultConfig.java
+++ b/src/main/java/org/zapply/product/global/vault/VaultConfig.java
@@ -1,0 +1,29 @@
+package org.zapply.product.global.vault;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultTemplate;
+
+@Configuration
+public class VaultConfig {
+
+    @Value("${spring.cloud.vault.token}")
+    private String vaultToken;
+
+    @Value("${spring.cloud.vault.uri}")
+    private String vaultEndpointUri;
+
+    /**
+     * VaultTemplate Bean 설정
+     */
+    @Bean
+    public VaultTemplate vaultTemplate() {
+
+        TokenAuthentication tokenAuthentication = new TokenAuthentication(vaultToken);
+
+        return new VaultTemplate(VaultEndpoint.from(vaultEndpointUri), tokenAuthentication);
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요
- #34 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 계정 연동시 Hashicorp vault에 토큰을 암호화해서 저장하도록 했습니다. 암호화방식은 만들어둔 `JasyptStringEncryptor`의  `AES256TextEncryptor`를 활용했습니다.
- 토큰 만료일, userId(게시물 발행 등의 api 사용을 위해서는 플랫폼 내 user id가 필요하더라고요)을 저장하는 필드를 `Account`에 추가해주었습니다.

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
