### PR TITLE
FEAT: Threads에 미디어를 발행한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
+++ b/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
@@ -1,0 +1,32 @@
+package org.zapply.product.domain.posting.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.zapply.product.domain.posting.dto.request.ThreadsPostingRequest;
+import org.zapply.product.domain.posting.dto.response.ThreadsPostingResponse;
+import org.zapply.product.global.apiPayload.response.ApiResponse;
+import org.zapply.product.global.security.AuthDetails;
+import org.zapply.product.global.threads.ThreadsPostingClient;
+
+@RestController
+@RequestMapping("/v1/posting")
+@RequiredArgsConstructor
+@Tag(name = "Posting", description = "게시글 발행 API")
+public class PostingController {
+
+    private final ThreadsPostingClient threadsPostingClient;
+
+    @PostMapping("/threads/{project_id}")
+    @Operation(summary = "스레드 미디어 발행하기", description = "스레드 미디어 발행하기(단일컨테이너)")
+    public ApiResponse<ThreadsPostingResponse> createMedia(@AuthenticationPrincipal AuthDetails authDetails,
+                                                                   @Valid @RequestBody ThreadsPostingRequest request,
+                                                                   @PathVariable("project_id") Long projectId) {
+        return ApiResponse.success(
+                threadsPostingClient.createMedia(authDetails.getMember(), request, projectId)
+        );
+    }
+}

--- a/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
+++ b/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
@@ -20,13 +20,23 @@ public class PostingController {
 
     private final ThreadsPostingClient threadsPostingClient;
 
-    @PostMapping("/threads/{project_id}")
-    @Operation(summary = "스레드 미디어 발행하기", description = "스레드 미디어 발행하기(단일컨테이너)")
-    public ApiResponse<ThreadsPostingResponse> createMedia(@AuthenticationPrincipal AuthDetails authDetails,
+    @PostMapping("/threads/{project_id}/single")
+    @Operation(summary = "스레드 미디어 단일 발행하기", description = "단일 미디어를 업로드하는 메소드. (media 하나만 업로드)")
+    public ApiResponse<ThreadsPostingResponse> createSingleMedia(@AuthenticationPrincipal AuthDetails authDetails,
+                                                                 @Valid @RequestBody ThreadsPostingRequest request,
+                                                                 @PathVariable("project_id") Long projectId) {
+        return ApiResponse.success(
+                threadsPostingClient.createSingleMedia(authDetails.getMember(), request, projectId)
+        );
+    }
+
+    @PostMapping("/threads/{project_id}/carousel")
+    @Operation(summary = "스레드 미디어 케러셀 발행하기", description = "캐러셀 미디어를 업로드하는 메소드. (media 여러개 업로드)")
+    public ApiResponse<ThreadsPostingResponse> createCarouselMedia(@AuthenticationPrincipal AuthDetails authDetails,
                                                                    @Valid @RequestBody ThreadsPostingRequest request,
                                                                    @PathVariable("project_id") Long projectId) {
         return ApiResponse.success(
-                threadsPostingClient.createMedia(authDetails.getMember(), request, projectId)
+                threadsPostingClient.createCarouselMedia(authDetails.getMember(), request, projectId)
         );
     }
 }

--- a/src/main/java/org/zapply/product/domain/posting/dto/request/ThreadsPostingRequest.java
+++ b/src/main/java/org/zapply/product/domain/posting/dto/request/ThreadsPostingRequest.java
@@ -1,0 +1,21 @@
+package org.zapply.product.domain.posting.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+
+public record ThreadsPostingRequest(
+        @NotNull
+        @Schema(description = "미디어 타입", example = "IMAGE || VIDEO || TEXT")
+        String mediaType,
+
+        @NotNull
+        @Schema(description = "미디어 url", example = "https://zaply-landing.vercel.app/assets/images/ZaplyLanding.webp")
+        String media,
+
+        @NotNull
+        @Schema(description = "미디어 텍스트", example = "미디어 텍스트")
+        @Max(value = 500, message = "미디어 텍스트는 500자 이내로 입력해주세요")
+        String text
+) {
+}

--- a/src/main/java/org/zapply/product/domain/posting/dto/request/ThreadsPostingRequest.java
+++ b/src/main/java/org/zapply/product/domain/posting/dto/request/ThreadsPostingRequest.java
@@ -4,14 +4,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 public record ThreadsPostingRequest(
         @NotNull
         @Schema(description = "미디어 타입", example = "IMAGE || VIDEO || TEXT")
         String mediaType,
 
         @NotNull
-        @Schema(description = "미디어 url", example = "https://zaply-landing.vercel.app/assets/images/ZaplyLanding.webp")
-        String media,
+        @Schema(description = "미디어 URL들",
+                example = "[\"https://zaply-landing.vercel.app/assets/images/ZaplyLanding.webp\"," +
+                        " \"https://zaply-landing.vercel.app/assets/images/ZaplyLanding.webp\"]")
+        List<String> media,
 
         @NotNull
         @Schema(description = "미디어 텍스트", example = "미디어 텍스트")

--- a/src/main/java/org/zapply/product/domain/posting/dto/response/ThreadsPostingResponse.java
+++ b/src/main/java/org/zapply/product/domain/posting/dto/response/ThreadsPostingResponse.java
@@ -1,0 +1,37 @@
+package org.zapply.product.domain.posting.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import org.zapply.product.domain.posting.entity.Posting;
+
+@Builder
+public record ThreadsPostingResponse(
+        @Schema(description = "게시물 ID", example = "1234567890")
+        String postingId,
+
+        @Schema(description = "게시된 미디어 ID", example = "1234567890")
+        String mediaId,
+
+        @Schema(description = "미디어 타입", example = "IMAGE || VIDEO || TEXT")
+        String mediaType,
+
+        @Schema(description = "미디어 URL", example = "https://zaply-landing.vercel.app/assets/images/ZaplyLanding.webp")
+        String media,
+
+        @Schema(description = "미디어 텍스트", example = "미디어 텍스트")
+        String text,
+
+        @Schema(description = "게시물 생성 시간", example = "2023-10-01T12:00:00Z")
+        String createdAt
+) {
+    public static ThreadsPostingResponse of(Posting posting, String mediaType, String media, String text) {
+        return ThreadsPostingResponse.builder()
+                .postingId(posting.getPostingId().toString())
+                .mediaId(posting.getMediaId())
+                .mediaType(mediaType)
+                .media(media)
+                .text(text)
+                .createdAt(posting.getCreatedAt().toString())
+                .build();
+    }
+}

--- a/src/main/java/org/zapply/product/domain/posting/entity/Posting.java
+++ b/src/main/java/org/zapply/product/domain/posting/entity/Posting.java
@@ -35,13 +35,18 @@ public class Posting extends BaseTimeEntity {
     @Column
     private String postingLink;
 
+    @Column
+    private String mediaId;
+
     @Builder
     public Posting(Project project, String postingTitle, SNSType postingType,
-                   PostingState postingState, String postingLink) {
+                   PostingState postingState, String postingLink, String mediaId) {
         this.project       = project;
         this.postingTitle  = postingTitle;
         this.postingType   = postingType;
         this.postingState  = postingState;
         this.postingLink   = postingLink;
+        this.mediaId       = mediaId;
     }
+
 }

--- a/src/main/java/org/zapply/product/domain/posting/repository/PostingRepository.java
+++ b/src/main/java/org/zapply/product/domain/posting/repository/PostingRepository.java
@@ -1,0 +1,7 @@
+package org.zapply.product.domain.posting.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zapply.product.domain.posting.entity.Posting;
+
+public interface PostingRepository extends JpaRepository<Posting, Long> {
+}

--- a/src/main/java/org/zapply/product/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/org/zapply/product/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package org.zapply.product.domain.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zapply.product.domain.project.entity.Project;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
+++ b/src/main/java/org/zapply/product/domain/user/repository/AccountRepository.java
@@ -1,7 +1,6 @@
 package org.zapply.product.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 import org.zapply.product.domain.user.entity.Account;
 import org.zapply.product.domain.user.entity.Member;
 import org.zapply.product.domain.user.enumerate.SNSType;
@@ -11,6 +10,5 @@ import java.util.Optional;
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByEmailAndAccountTypeAndMember(String email, SNSType accountType, Member member);
     Optional<Account> findByAccountNameAndAccountTypeAndMember(String accountName, SNSType accountType, Member member);
-    Optional<Account> findByAccountTypeAndMember(@Param("accountType") SNSType accountType,
-                                              @Param("member") Member member);
+    Optional<Account> findByAccountTypeAndMember(SNSType accountType, Member member);
 }

--- a/src/main/java/org/zapply/product/domain/user/service/AccountService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AccountService.java
@@ -10,12 +10,12 @@ import org.zapply.product.domain.user.enumerate.SNSType;
 import org.zapply.product.domain.user.repository.AccountRepository;
 import org.zapply.product.global.apiPayload.exception.CoreException;
 import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
-import org.zapply.product.global.security.facebook.FacebookClient;
-import org.zapply.product.global.security.facebook.FacebookProfile;
-import org.zapply.product.global.security.facebook.FacebookToken;
-import org.zapply.product.global.security.threads.ThreadsClient;
-import org.zapply.product.global.security.threads.ThreadsProfile;
-import org.zapply.product.global.security.threads.ThreadsToken;
+import org.zapply.product.global.facebook.FacebookClient;
+import org.zapply.product.global.facebook.FacebookProfile;
+import org.zapply.product.global.facebook.FacebookToken;
+import org.zapply.product.global.threads.ThreadsClient;
+import org.zapply.product.global.threads.ThreadsProfile;
+import org.zapply.product.global.threads.ThreadsToken;
 import org.zapply.product.global.vault.VaultClient;
 
 import java.security.MessageDigest;

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
@@ -24,6 +24,7 @@ public enum GlobalErrorType implements ErrorType {
     FACEBOOK_API_ERROR(HttpStatus.BAD_REQUEST, "페이스북 API 호출에 실패했습니다."),
     THREADS_API_ERROR(HttpStatus.BAD_REQUEST, "스레드 API 호출에 실패했습니다."),
     THREADS_CREATION_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "스레드 미디어 컨테이너 ID를 찾을 수 없습니다."),
+    THREADS_MEDIA_NOT_READY(HttpStatus.BAD_REQUEST, "스레드 미디어가 준비되지 않았습니다."),
     ACCOUNT_TOKEN_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "계정의 토큰 키를 찾을 수 없습니다."),
     SNS_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 SNS 타입입니다."),
 

--- a/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/org/zapply/product/global/apiPayload/exception/GlobalErrorType.java
@@ -19,9 +19,11 @@ public enum GlobalErrorType implements ErrorType {
 
     // Account
     ALREADY_EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 존재하는 계정입니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일이 존재하지 않습니다."),
     FACEBOOK_API_ERROR(HttpStatus.BAD_REQUEST, "페이스북 API 호출에 실패했습니다."),
     THREADS_API_ERROR(HttpStatus.BAD_REQUEST, "스레드 API 호출에 실패했습니다."),
+    THREADS_CREATION_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "스레드 미디어 컨테이너 ID를 찾을 수 없습니다."),
     ACCOUNT_TOKEN_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "계정의 토큰 키를 찾을 수 없습니다."),
     SNS_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 SNS 타입입니다."),
 
@@ -45,7 +47,10 @@ public enum GlobalErrorType implements ErrorType {
 
     // Vault
     VAULT_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Vault에 토큰이 존재하지 않습니다."),
-    ;
+
+
+    // Project
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로젝트입니다.");
 
     private final HttpStatus status;
 

--- a/src/main/java/org/zapply/product/global/facebook/FacebookClient.java
+++ b/src/main/java/org/zapply/product/global/facebook/FacebookClient.java
@@ -1,4 +1,4 @@
-package org.zapply.product.global.security.facebook;
+package org.zapply.product.global.facebook;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/org/zapply/product/global/facebook/FacebookProfile.java
+++ b/src/main/java/org/zapply/product/global/facebook/FacebookProfile.java
@@ -1,4 +1,4 @@
-package org.zapply.product.global.security.facebook;
+package org.zapply.product.global.facebook;
 
 public record FacebookProfile(
         String id,

--- a/src/main/java/org/zapply/product/global/facebook/FacebookToken.java
+++ b/src/main/java/org/zapply/product/global/facebook/FacebookToken.java
@@ -1,4 +1,4 @@
-package org.zapply.product.global.security.facebook;
+package org.zapply.product.global.facebook;
 
 public record FacebookToken(
         String accessToken

--- a/src/main/java/org/zapply/product/global/threads/ThreadsClient.java
+++ b/src/main/java/org/zapply/product/global/threads/ThreadsClient.java
@@ -1,4 +1,4 @@
-package org.zapply.product.global.security.threads;
+package org.zapply.product.global.threads;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/org/zapply/product/global/threads/ThreadsPostingClient.java
+++ b/src/main/java/org/zapply/product/global/threads/ThreadsPostingClient.java
@@ -1,0 +1,147 @@
+package org.zapply.product.global.threads;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.zapply.product.domain.posting.dto.request.ThreadsPostingRequest;
+import org.zapply.product.domain.posting.dto.response.ThreadsPostingResponse;
+import org.zapply.product.domain.posting.entity.Posting;
+import org.zapply.product.domain.posting.enumerate.PostingState;
+import org.zapply.product.domain.posting.repository.PostingRepository;
+import org.zapply.product.domain.project.entity.Project;
+import org.zapply.product.domain.project.repository.ProjectRepository;
+import org.zapply.product.domain.user.entity.Account;
+import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.enumerate.SNSType;
+import org.zapply.product.domain.user.repository.AccountRepository;
+import org.zapply.product.domain.user.service.AccountService;
+import org.zapply.product.global.apiPayload.exception.CoreException;
+import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
+
+import java.net.URI;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ThreadsPostingClient {
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String THREADS_API_BASE = "https://graph.threads.net/v1.0";
+    private final AccountRepository accountRepository;
+    private final AccountService accountService;
+    private final ProjectRepository projectRepository;
+    private final PostingRepository postingRepository;
+
+    private Account getThreadsAccount(Member member) {
+        return accountRepository.findByAccountTypeAndMember(SNSType.THREADS, member)
+                .orElseThrow(() -> new CoreException(GlobalErrorType.ACCOUNT_NOT_FOUND));
+    }
+
+    private String getAccessToken(Member member) {
+        return accountService.getAccessToken(member, SNSType.THREADS);
+    }
+
+    /**
+     * 스레드에 미디어 컨테이너 생성하기
+     * @param member
+     * @param request
+     * @param projectId
+     * @return 생성된 미디어 컨테이너 ID
+     */
+    public ThreadsPostingResponse createMedia(Member member, ThreadsPostingRequest request, Long projectId) {
+        try {
+            Account account = getThreadsAccount(member);
+            String accessToken = getAccessToken(member);
+
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(THREADS_API_BASE + "/" + account.getUserId() + "/threads")
+                    .queryParam("media_type", request.mediaType())
+                    .queryParam("image_url", request.media())
+                    .queryParam("text", request.text())
+                    .queryParam("access_token", accessToken)
+                    .build()
+                    .encode()
+                    .toUri();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.POST,
+                    new HttpEntity<>(headers),
+                    Map.class
+            );
+
+            Map<String, Object> body = response.getBody();
+
+            if (body == null || body.get("id") == null) {
+                throw new CoreException(GlobalErrorType.THREADS_CREATION_ID_NOT_FOUND);
+            }
+            return publishMedia(member, String.valueOf(body.get("id")), projectId,
+                    request.mediaType(), request.media(), request.text());
+
+        } catch (Exception e) {
+            throw new CoreException(GlobalErrorType.THREADS_API_ERROR);
+        }
+    }
+
+    /**
+     * 스레드에 미디어 컨테이너 게시하기
+     * @param member
+     * @param creationId
+     * @param projectId
+     * @param mediaType
+     * @param media
+     * @param text
+     * @return 게시된 미디어 컨테이너 ID
+     */
+    public ThreadsPostingResponse publishMedia(Member member, String creationId, Long projectId,
+                                                        String mediaType, String media, String text) {
+        try {
+
+            Project project = projectRepository.findById(projectId)
+                    .orElseThrow(() -> new CoreException(GlobalErrorType.PROJECT_NOT_FOUND));
+            Account account = getThreadsAccount(member);
+            String accessToken = getAccessToken(member);
+
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(THREADS_API_BASE + "/" + account.getUserId() + "/threads_publish")
+                    .queryParam("creation_id", creationId)
+                    .queryParam("access_token", accessToken)
+                    .build()
+                    .encode()
+                    .toUri();
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.POST,
+                    new HttpEntity<>(new HttpHeaders()),
+                    Map.class
+            );
+
+            Map<String, Object> body = response.getBody();
+
+            Posting posting = Posting.builder()
+                    .postingLink("")
+                    .postingTitle("")
+                    .postingType(SNSType.THREADS)
+                    .postingState(PostingState.POSTED)
+                    .project(project)
+                    .mediaId(String.valueOf(body.get("id")))
+                    .build();
+
+            postingRepository.save(posting);
+            return ThreadsPostingResponse.of(posting, mediaType, media, text);
+
+        } catch (Exception e) {
+            throw new CoreException(GlobalErrorType.THREADS_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/zapply/product/global/threads/ThreadsProfile.java
+++ b/src/main/java/org/zapply/product/global/threads/ThreadsProfile.java
@@ -1,4 +1,4 @@
-package org.zapply.product.global.security.threads;
+package org.zapply.product.global.threads;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/org/zapply/product/global/threads/ThreadsToken.java
+++ b/src/main/java/org/zapply/product/global/threads/ThreadsToken.java
@@ -1,4 +1,4 @@
-package org.zapply.product.global.security.threads;
+package org.zapply.product.global.threads;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 


### PR DESCRIPTION
## 💡 관련 이슈
- #42 


## 📝 작업 내용

<img width="1465" alt="스크린샷 2025-05-13 오후 3 32 52" src="https://github.com/user-attachments/assets/0b721689-d41c-4d4e-a65c-3c5dbdc79f48" />

API 링크: [Threads API](https://developers.facebook.com/docs/threads/posts)

스레드에서 단일 미디어를 발행할 수 있는 API, 여러 미디어를 발행할 수 있는 캐러셀 API를 제공하고 있어서 우선 두 개 모두 구현해두었습니다!

**1. 단일 미디어 발행**
<img width="1501" alt="스크린샷 2025-05-13 오후 3 36 13" src="https://github.com/user-attachments/assets/0550f8e1-f20c-454b-9c94-8d5fb93362c5" />
위와 같이 요청 하면, 단일 미디어 컨테이너 생성 -> 발행  총 2가지의 API를 거쳐 아래와 같이 미디어가 포스팅됩니다.
<img width="687" alt="스크린샷 2025-05-13 오후 3 37 09" src="https://github.com/user-attachments/assets/10639247-ac83-4096-9aa2-acc5a82567bc" />


**2. 캐러셀 미디어 발행**
<img width="1546" alt="스크린샷 2025-05-13 오후 3 37 21" src="https://github.com/user-attachments/assets/3eb52342-ecdd-4ac1-b804-b1e720b90a6d" />
위와 같이 요청하면, 사진의 개수만큼 미디어 컨테이너 생성 -> 캐러셀 컨테이너 생성 -> 캐러셀 발행 3가지의 API를 거쳐 아래와 같이 미디어가 포스팅됩니다.
<img width="724" alt="스크린샷 2025-05-13 오후 3 38 02" src="https://github.com/user-attachments/assets/2dca389a-64de-422f-be09-d25f4683098b" />


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
