### PR TITLE
FIX: Facebook, Threads의 계정 연동 flow를 수정한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -1,24 +1,38 @@
 package org.zapply.product.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.zapply.product.domain.user.enumerate.SNSType;
 import org.zapply.product.domain.user.service.AccountService;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
+import org.zapply.product.global.facebook.FacebookClient;
 import org.zapply.product.global.security.AuthDetails;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/v1/account")
 @RequiredArgsConstructor
 public class AccountController {
+    private static final Logger log = LoggerFactory.getLogger(AccountController.class);
     private final AccountService accountService;
+    private final FacebookClient facebookClient;
 
-    @PostMapping("/facebook/link")
-    @Operation(summary = "페이스북 계정 연동", description = "페이스북 계정 연동")
-    public ApiResponse<?> signInWithGoogle(@RequestParam("code") String code, @AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.success(accountService.linkFacebook(code, authDetails.getMember()));
+    @GetMapping("/facebook/login")
+    @Operation(summary = "페이스북 계정연동", description = "페이스북 계정연동")
+    public void loginFacebook(HttpServletResponse response,
+                              @AuthenticationPrincipal AuthDetails authDetails) throws IOException {
+        response.sendRedirect(facebookClient.buildAuthorizationUri(authDetails.getMember()));
+    }
+
+    @GetMapping("/facebook/link")
+    @Operation(summary = "페이스북 액세스 토큰 발급", description = "페이스북 액세스 토큰 발급")
+    public ApiResponse<String> linkFacebook(@RequestParam("code") String code, @RequestParam("state") Long memberId) {
+        return ApiResponse.success(accountService.linkFacebook(code, memberId));
     }
 
     @PostMapping("/threads/link")

--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -11,6 +11,7 @@ import org.zapply.product.domain.user.service.AccountService;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
 import org.zapply.product.global.facebook.FacebookClient;
 import org.zapply.product.global.security.AuthDetails;
+import org.zapply.product.global.threads.ThreadsClient;
 
 import java.io.IOException;
 
@@ -21,23 +22,31 @@ public class AccountController {
     private static final Logger log = LoggerFactory.getLogger(AccountController.class);
     private final AccountService accountService;
     private final FacebookClient facebookClient;
+    private final ThreadsClient threadsClient;
 
     @GetMapping("/facebook/login")
-    @Operation(summary = "페이스북 계정연동", description = "페이스북 계정연동")
+    @Operation(summary = "페이스북 계정연동", description = "페이스북 계정연동 url 생성 (accessToken 필요)")
     public void loginFacebook(HttpServletResponse response,
                               @AuthenticationPrincipal AuthDetails authDetails) throws IOException {
         response.sendRedirect(facebookClient.buildAuthorizationUri(authDetails.getMember()));
     }
 
     @GetMapping("/facebook/link")
-    @Operation(summary = "페이스북 액세스 토큰 발급", description = "페이스북 액세스 토큰 발급")
+    @Operation(summary = "페이스북 액세스 토큰 발급", description = "페이스북 액세스 토큰 발급 (계정연동 API에서 연결되는 URL)")
     public ApiResponse<String> linkFacebook(@RequestParam("code") String code, @RequestParam("state") Long memberId) {
         return ApiResponse.success(accountService.linkFacebook(code, memberId));
     }
 
-    @PostMapping("/threads/link")
-    @Operation(summary = "스레드 계정 연동", description = "스레드 계정 연동")
-    public ApiResponse<?> signInWithThreads(@RequestParam("code") String code, @AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.success(accountService.linkThreads(code, authDetails.getMember()));
+    @GetMapping("/threads/login")
+    @Operation(summary = "스레드 계정연동", description = "스레드 계정연동 생성 (accessToken 필요)")
+    public void loginThreads(HttpServletResponse response,
+                              @AuthenticationPrincipal AuthDetails authDetails) throws IOException {
+        response.sendRedirect(threadsClient.buildAuthorizationUri(authDetails.getMember().getId()));
+    }
+
+    @GetMapping("/threads/link")
+    @Operation(summary = "스레드 액세스 토큰 발급", description = "스레드 액세스 토큰 발급 (계정연동 API에서 연결되는 URL)")
+    public ApiResponse<String> signInWithThreads(@RequestParam("code") String code, @RequestParam("state") Long memberId){
+        return ApiResponse.success(accountService.linkThreads(code, memberId));
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/service/AccountService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AccountService.java
@@ -8,6 +8,7 @@ import org.zapply.product.domain.user.entity.Account;
 import org.zapply.product.domain.user.entity.Member;
 import org.zapply.product.domain.user.enumerate.SNSType;
 import org.zapply.product.domain.user.repository.AccountRepository;
+import org.zapply.product.domain.user.repository.MemberRepository;
 import org.zapply.product.global.apiPayload.exception.CoreException;
 import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 import org.zapply.product.global.facebook.FacebookClient;
@@ -31,6 +32,7 @@ public class AccountService {
     private final FacebookClient facebookClient;
     private final ThreadsClient threadsClient;
     private final VaultClient vaultClient;
+    private final MemberRepository memberRepository;
 
     @Value("${spring.security.oauth2.client.registration.facebook.redirect-uri}")
     private String facebookRedirectUrl;
@@ -49,10 +51,12 @@ public class AccountService {
      * 페이스북 계정 연동
      *
      * @param code
-     * @param member
+     * @param memberId
      * @return Redis Key
      */
-    public String linkFacebook(String code, Member member) {
+    public String linkFacebook(String code, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
         // 페이스북으로 액세스 토큰 요청하기
         FacebookToken shortFacebookAccessToken = facebookClient.getFacebookAccessToken(code, facebookRedirectUrl);
         FacebookToken longFacebookAccessToken = facebookClient.getLongLivedToken(shortFacebookAccessToken.accessToken());

--- a/src/main/java/org/zapply/product/domain/user/service/AccountService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AccountService.java
@@ -102,10 +102,14 @@ public class AccountService {
      * 스레드 계정 연동
      *
      * @param code
-     * @param member
+     * @param memberId
      * @return Redis Key
      */
-    public String linkThreads(String code, Member member) {
+    public String linkThreads(String code, Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
+
         // 스레드로 액세스 토큰 요청하기
         ThreadsToken shortThreadsToken = threadsClient.getThreadsAccessToken(code, threadsRedirectUrl);
 

--- a/src/main/java/org/zapply/product/global/config/SecurityConfig.java
+++ b/src/main/java/org/zapply/product/global/config/SecurityConfig.java
@@ -86,7 +86,8 @@ public class SecurityConfig {
                                 "/oauth2/callback/**",
                                 "/api/auth/google/**",
                                 "/api/oauth/callback/*",
-                                "/v1/account/facebook/link"
+                                "/v1/account/facebook/link",
+                                "/v1/account/facebook/login"
                         ).permitAll()
 
                         // 문자 인증

--- a/src/main/java/org/zapply/product/global/config/SecurityConfig.java
+++ b/src/main/java/org/zapply/product/global/config/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
                                 "/api/auth/google/**",
                                 "/api/oauth/callback/*",
                                 "/v1/account/facebook/link",
-                                "/v1/account/facebook/login"
+                                "/v1/account/threads/link"
                         ).permitAll()
 
                         // 문자 인증

--- a/src/main/java/org/zapply/product/global/threads/ThreadsClient.java
+++ b/src/main/java/org/zapply/product/global/threads/ThreadsClient.java
@@ -11,9 +11,12 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.zapply.product.domain.user.repository.MemberRepository;
 import org.zapply.product.global.apiPayload.exception.CoreException;
 import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -21,6 +24,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class ThreadsClient {
+    private final MemberRepository memberRepository;
     @Value("${spring.security.oauth2.client.registration.threads.client-id}")
     private String clientId;
 
@@ -36,8 +40,27 @@ public class ThreadsClient {
     @Value("${spring.security.oauth2.client.provider.threads.user-info-uri}")
     private String userInfoUrl;
 
+    @Value("${spring.security.oauth2.client.registration.threads.redirect-uri}")
+    private String redirectUri;
+
     private final ObjectMapper objectMapper;
     private final RestClient restClient = RestClient.create();
+
+    /**
+     * 스레드 로그인 URL 생성
+     * @param memberId
+     * @return 스레드 로그인 URL
+     */
+    public String buildAuthorizationUri(Long memberId) {
+        String uri = redirectUri + "?state=" + memberId;
+        return UriComponentsBuilder.fromHttpUrl("https://threads.net/oauth/authorize")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("scope", "threads_basic,threads_content_publish,threads_manage_replies,threads_manage_insights,threads_read_replies,threads_manage_mentions,threads_keyword_search,threads_delete")
+                .queryParam("response_type", "code")
+                .toUriString();
+    }
+
 
     /**
      * 스레드로부터 받은 인가코드를 통해 액세스 토큰 요청하기
@@ -46,12 +69,16 @@ public class ThreadsClient {
      * @return ThreadsToken
      */
     public ThreadsToken getThreadsAccessToken(String code, String redirectUri) {
+
+        String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+        String cleanCode = decodedCode.split("#")[0];  // code 이후의 #_ 제거
+
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("client_id", clientId);
         formData.add("client_secret", clientSecret);
         formData.add("grant_type", grantType);
         formData.add("redirect_uri", redirectUri);
-        formData.add("code", code);
+        formData.add("code", cleanCode);
 
         String response = restClient.post()
                 .uri(accessTokenUrl)


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #40


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

`/v1/acoount/facebook/login`으로 jwt토큰과 함께 GET 요청 시 자동으로 `v1/account/facebook/link`로 넘어가 장기발행 토큰을 발급할 수 있도록 하였습니다. Threads도 같은 방식으로 작동하도록 수정했습니다.
<img width="1515" alt="스크린샷 2025-05-14 오후 12 40 54" src="https://github.com/user-attachments/assets/bac62203-a373-487c-aa6d-994a52c37560" />
즉 프론트는 `/v1/acoount/facebook/login`, `/v1/acoount/threads/login` API만 사용하면 될 것 같습니다!

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
