### PR TITLE
REFACTOR: 로그인 응답 구조에 연동된 계정 정보와, 사용자 정보를 포함시킨다

### DIFF
--- a/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.zapply.product.domain.user.dto.request.AuthRequest;
 import org.zapply.product.domain.user.dto.request.SignInRequest;
+import org.zapply.product.domain.user.dto.response.LoginResponse;
 import org.zapply.product.domain.user.dto.response.MemberResponse;
 import org.zapply.product.domain.user.dto.response.TokenResponse;
 import org.zapply.product.domain.user.service.AccountService;
@@ -39,7 +40,7 @@ public class AuthController {
 
     @PostMapping("/sign-in")
     @Operation(summary = "로그인", description = "로그인 기능")
-    public ApiResponse<TokenResponse> signIn(@Valid @RequestBody SignInRequest signInRequest) {
+    public ApiResponse<LoginResponse> signIn(@Valid @RequestBody SignInRequest signInRequest) {
         return ApiResponse.success(authService.signIn(signInRequest));
     }
 
@@ -79,3 +80,4 @@ public class AuthController {
         return ApiResponse.success(accountService.getAccountsInfo(authDetails.getMember()));
     }
 }
+

--- a/src/main/java/org/zapply/product/domain/user/dto/response/LoginResponse.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/response/LoginResponse.java
@@ -1,0 +1,25 @@
+package org.zapply.product.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record LoginResponse(
+        @Schema(description = "토큰 정보", example = "액세스토큰, 리프레쉬 토큰")
+        TokenResponse tokenResponse,
+
+        @Schema(description = "사용자 정보", example = "회원 ID, 이름, 이메일, 휴대폰 번호")
+        MemberResponse memberResponse,
+
+        @Schema(description = "연동된 계정 정보", example = "연동계정 갯수, 연동계정 플랫폼, 연동계정 이름")
+        AccountsInfoResponse accountsInfoResponse
+) {
+    public static LoginResponse of(TokenResponse tokenResponse, MemberResponse memberResponse, AccountsInfoResponse accountsInfoResponse) {
+        return LoginResponse.builder()
+                .tokenResponse(tokenResponse)
+                .memberResponse(memberResponse)
+                .accountsInfoResponse(accountsInfoResponse)
+                .build();
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/dto/response/MemberResponse.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/response/MemberResponse.java
@@ -7,7 +7,7 @@ import org.zapply.product.domain.user.entity.Member;
 @Builder
 public record MemberResponse(
         @Schema(description = "회원 ID", example = "1")
-        Long id,
+        Long memberId,
 
         @Schema(description = "이름", example = "홍길동")
         String name,
@@ -20,7 +20,7 @@ public record MemberResponse(
 ) {
     public static MemberResponse of(Member member) {
         return MemberResponse.builder()
-                .id(member.getId())
+                .memberId(member.getId())
                 .name(member.getName())
                 .email(member.getEmail())
                 .phoneNumber(member.getPhoneNumber())

--- a/src/main/java/org/zapply/product/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/response/TokenResponse.java
@@ -3,13 +3,11 @@ import lombok.Builder;
 
 @Builder
 public record TokenResponse(
-        Long memberId,
         String accessToken,
         String refreshToken
 ) {
-    public static TokenResponse of(Long memberId, String accessToken, String refreshToken) {
+    public static TokenResponse of(String accessToken, String refreshToken) {
         return TokenResponse.builder()
-                .memberId(memberId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/org/zapply/product/global/security/jwt/JwtProvider.java
+++ b/src/main/java/org/zapply/product/global/security/jwt/JwtProvider.java
@@ -82,7 +82,6 @@ public class JwtProvider {
      */
     public TokenResponse createToken(Member member) {
         return TokenResponse.of(
-                member.getId(),
                 createAccessToken(member),
                 createRefreshToken(member)
         );
@@ -100,7 +99,7 @@ public class JwtProvider {
         if(getExpirationTime(refreshToken) <= getExpirationTime(accessToken)) {
             refreshToken = createRefreshToken(member);
         }
-        return TokenResponse.of(member.getId(), accessToken, refreshToken);
+        return TokenResponse.of(accessToken, refreshToken);
     }
 
     /**


### PR DESCRIPTION
## 💡 관련 이슈
- #72 

## 📝 작업 내용
- 일반 로그인 시 로그인 응답구조를 변경하였습니다.
- 소셜 로그인 시 로그인 응답구조를 변경하였습니다.

## 🧑‍💻 변경 사항
- tokenResponse,MemberResponse, AccountsInfoResponse를 묶어서 하나의 응답 구조를 만들었습니다.
- 현재 tokenResponse, MemberResponse에 모두 memberId 필드가 존재해 추후 수정이 필요해보입니다.
- 프론트에서 로그인 응답을 쿠키에 어떻게 저장할 지에 따라서 소셜 로그인 응답도 추후 수정할 예정입니다.

## 💬 리뷰 요구사항(선택)
