### PR TITLE
FEAT: 게시글을 기반으로 제목을 추천한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/posting/controller/ClovaController.java
+++ b/src/main/java/org/zapply/product/domain/posting/controller/ClovaController.java
@@ -4,27 +4,29 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.zapply.product.domain.posting.dto.request.ThreadsPostingRequest;
 import org.zapply.product.domain.posting.dto.request.ToneTransferRequest;
-import org.zapply.product.domain.posting.dto.response.ThreadsPostingResponse;
-import org.zapply.product.domain.posting.service.ToneTransferService;
+import org.zapply.product.domain.posting.service.ClovaService;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
-import org.zapply.product.global.security.AuthDetails;
 
 @RestController
 @RequestMapping("/v1/posting")
 @RequiredArgsConstructor
 @Tag(name = "Posting", description = "게시글 발행 API")
-public class ToneTransferController {
+public class ClovaController {
 
-    private final ToneTransferService toneTransferService;
+    private final ClovaService clovaService;
 
     @PostMapping("/transfer")
     @Operation(summary = "SNS 글 분위기 변환", description = "입력된 콘텐츠를 지정된 SNS 타입에 맞춰 변환합니다.")
     public ApiResponse<String> transferToSNSTone(@Valid @RequestBody ToneTransferRequest toneTransferRequest) {
-        return ApiResponse.success(toneTransferService.TransferToSNSTone(toneTransferRequest));
+        return ApiResponse.success(clovaService.TransferToSNSTone(toneTransferRequest));
+    }
+
+    @PostMapping("/title")
+    @Operation(summary = "글에 맞는 컨텐츠 제목 추천", description = "하나의 게시글을 입력받고 전체 컨텐츠의 제목을 추천해줍니다.")
+    public ApiResponse<String> recommendProjectTitle(@Valid @RequestBody ToneTransferRequest toneTransferRequest) {
+        return ApiResponse.success(clovaService.recommendProjectTitle(toneTransferRequest));
     }
 
 }

--- a/src/main/java/org/zapply/product/domain/posting/service/ClovaService.java
+++ b/src/main/java/org/zapply/product/domain/posting/service/ClovaService.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 @Log4j2
-public class ToneTransferService {
+public class ClovaService {
 
     @Value("${cloud.ncp.clova.api-key}")
     private String apiKey;
@@ -37,6 +37,9 @@ public class ToneTransferService {
 
     @Value("${prompt.snstype.facebook}")
     private String facebookPrompt;
+
+    @Value("${prompt.title.system}")
+    private String titleSystemPrompt;
 
     private final ClovaAiClient clovaAiClient;
 
@@ -65,4 +68,22 @@ public class ToneTransferService {
             throw new CoreException(GlobalErrorType.CLOVA_API_ERROR);
         }
     }
+
+    public String recommendProjectTitle(ToneTransferRequest toneTransferRequest) {
+        String authorizationHeader = "Bearer " + apiKey;
+        String userPrompt = toneTransferRequest.userPrompt();
+        String systemPrompt = titleSystemPrompt;
+        try{
+            ClovaRequest clovaRequset = ClovaRequest.from(List.of(
+                    ClovaMessage.of(ClovaRole.SYSTEM.getValue(), systemPrompt),
+                    ClovaMessage.of(ClovaRole.USER.getValue(),   userPrompt)
+            ));
+            ClovaResponse clovaResponse = clovaAiClient.getCompletions(authorizationHeader, modelName, clovaRequset);
+            return clovaResponse.result().message().content();
+        } catch (Exception e) {
+            log.error("변환 중 오류 발생 요청 데이터: {}", userPrompt, e);
+            throw new CoreException(GlobalErrorType.CLOVA_API_ERROR);
+        }
+    }
+
 }

--- a/src/test/java/org/zapply/product/global/clova/ClovaAiClientTest.java
+++ b/src/test/java/org/zapply/product/global/clova/ClovaAiClientTest.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.zapply.product.domain.posting.dto.request.ToneTransferRequest;
-import org.zapply.product.domain.posting.service.ToneTransferService;
+import org.zapply.product.domain.posting.service.ClovaService;
 import org.zapply.product.global.clova.dto.ClovaMessage;
 import org.zapply.product.global.clova.enuermerate.SNSType;
 import org.zapply.product.global.clova.dto.request.ClovaRequest;
@@ -22,7 +22,7 @@ class ClovaAiClientTest {
     private ClovaAiClient clovaAiClient;
 
     @Autowired
-    private ToneTransferService toneTransferService;
+    private ClovaService clovaService;
 
     @Value("${cloud.ncp.clova.api-key}")
     private String apiKey;
@@ -55,7 +55,7 @@ class ClovaAiClientTest {
                 SNSType.THREADS,
                 "오늘은 정말 기분이 좋다. 날씨도 좋고, 친구들과 함께하는 시간이 너무 즐거워."
         );
-        String storyLines = toneTransferService.TransferToSNSTone(toneTransferRequest);
+        String storyLines = clovaService.TransferToSNSTone(toneTransferRequest);
         System.out.println(storyLines);
     }
 
@@ -65,7 +65,7 @@ class ClovaAiClientTest {
                 SNSType.INSTAGRAM,
                 "오늘은 정말 기분이 좋다. 날씨도 좋고, 친구들과 함께하는 시간이 너무 즐거워."
         );
-        String storyLines = toneTransferService.TransferToSNSTone(toneTransferRequest);
+        String storyLines = clovaService.TransferToSNSTone(toneTransferRequest);
         System.out.println(storyLines);
     }
 
@@ -75,7 +75,17 @@ class ClovaAiClientTest {
                 SNSType.FACEBOOK,
                 "오늘은 정말 기분이 좋다. 날씨도 좋고, 친구들과 함께하는 시간이 너무 즐거워."
         );
-        String storyLines = toneTransferService.TransferToSNSTone(toneTransferRequest);
+        String storyLines = clovaService.TransferToSNSTone(toneTransferRequest);
         System.out.println(storyLines);
+    }
+
+    @Test
+    public void 제목_추천() {
+        ToneTransferRequest toneTransferRequest = new ToneTransferRequest(
+                SNSType.FACEBOOK,
+                "오늘은 정말 기분이 좋다. 날씨도 좋고, 친구들과 함께하는 시간이 너무 즐거워."
+        );
+        String projectTitle = clovaService.recommendProjectTitle(toneTransferRequest);
+        System.out.println(projectTitle);
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #74 

## 📝 작업 내용
- 메인 플랫폼의게시글  내용을 입력받아 전체 컨텐츠(프로젝트)를 관리할 수 있는 제목을 추천받습니다.

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요
- [application-prompt.yml](https://www.notion.so/Zaply-1c73db3857da8053bebec3148704031d?p=1e23db3857da8059813de6cb40e9e24e&pm=s) 에 제목 추천 프롬프트 추가해서 수정해두었습니다.

## 💬 리뷰 요구사항(선택)