### PR TITLE
FEAT: 마이페이지에서 나의 정보를 수정한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -24,9 +24,7 @@ import java.net.http.HttpHeaders;
 @RequestMapping("/v1/account")
 @RequiredArgsConstructor
 public class AccountController {
-    private static final Logger log = LoggerFactory.getLogger(AccountController.class);
     private final AccountService accountService;
-    private final FacebookClient facebookClient;
     private final ThreadsClient threadsClient;
 
     @GetMapping("/facebook/link")

--- a/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
@@ -15,6 +15,7 @@ import org.zapply.product.domain.user.dto.response.MemberResponse;
 import org.zapply.product.domain.user.dto.response.TokenResponse;
 import org.zapply.product.domain.user.service.AccountService;
 import org.zapply.product.domain.user.service.AuthService;
+import org.zapply.product.domain.user.service.UserService;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
 import org.zapply.product.global.security.AuthDetails;
 import org.zapply.product.global.security.jwt.JwtProvider;
@@ -25,6 +26,7 @@ import org.zapply.product.global.security.jwt.JwtProvider;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final UserService userService;
     @Value("${jwt.header}")
     private String tokenHeader;
 
@@ -78,6 +80,12 @@ public class AuthController {
     @Operation(summary = "사용자 연동 계정 조회", description = "사용자가 연동한 계정 조회")
     public ApiResponse<?> getUserAccount(@AuthenticationPrincipal AuthDetails authDetails) {
         return ApiResponse.success(accountService.getAccountsInfo(authDetails.getMember()));
+    }
+
+    @PatchMapping("/mypage")
+    @Operation(summary = "사용자 이름 수정", description = "사용자 이름 수정")
+    public ApiResponse<?> updateUserName(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam("name") String name) {
+        return ApiResponse.success(userService.updateUserName(authDetails.getMember(), name));
     }
 }
 

--- a/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AuthController.java
@@ -15,7 +15,7 @@ import org.zapply.product.domain.user.dto.response.MemberResponse;
 import org.zapply.product.domain.user.dto.response.TokenResponse;
 import org.zapply.product.domain.user.service.AccountService;
 import org.zapply.product.domain.user.service.AuthService;
-import org.zapply.product.domain.user.service.UserService;
+import org.zapply.product.domain.user.service.MemberService;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
 import org.zapply.product.global.security.AuthDetails;
 import org.zapply.product.global.security.jwt.JwtProvider;
@@ -26,13 +26,11 @@ import org.zapply.product.global.security.jwt.JwtProvider;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final UserService userService;
     @Value("${jwt.header}")
     private String tokenHeader;
 
     private final AuthService authService;
     private final JwtProvider jwtProvider;
-    private final AccountService accountService;
 
     @PostMapping("/sign-up")
     @Operation(summary = "회원가입", description = "사용자의 정보 입력 후 회원가입")
@@ -67,25 +65,6 @@ public class AuthController {
     @Operation(summary = "이메일 중복 확인", description = "이메일 중복 확인. true - 중복, false - 사용 가능")
     public ApiResponse<Boolean> checkEmailDuplicate(@RequestParam("email") String email) {
         return ApiResponse.success(authService.checkEmailDuplicate(email));
-    }
-
-    @GetMapping()
-    @Operation(summary = "사용자 정보 조회(이름, 이메일)", description = "jwt 토큰을 통해 사용자 정보 조회")
-    public ApiResponse<MemberResponse> getUserInformation(@AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.success(MemberResponse.of(authDetails.getMember()));
-    }
-
-    // 사용자가 연동한 account를 조회
-    @GetMapping("/accounts")
-    @Operation(summary = "사용자 연동 계정 조회", description = "사용자가 연동한 계정 조회")
-    public ApiResponse<?> getUserAccount(@AuthenticationPrincipal AuthDetails authDetails) {
-        return ApiResponse.success(accountService.getAccountsInfo(authDetails.getMember()));
-    }
-
-    @PatchMapping("/mypage")
-    @Operation(summary = "사용자 이름 수정", description = "사용자 이름 수정")
-    public ApiResponse<?> updateUserName(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam("name") String name) {
-        return ApiResponse.success(userService.updateUserName(authDetails.getMember(), name));
     }
 }
 

--- a/src/main/java/org/zapply/product/domain/user/controller/MemberController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/MemberController.java
@@ -1,0 +1,40 @@
+package org.zapply.product.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.zapply.product.domain.user.dto.response.MemberResponse;
+import org.zapply.product.domain.user.service.AccountService;
+import org.zapply.product.domain.user.service.MemberService;
+import org.zapply.product.global.apiPayload.response.ApiResponse;
+import org.zapply.product.global.security.AuthDetails;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final AccountService accountService;
+    private final MemberService memberService;
+
+    @GetMapping()
+    @Operation(summary = "사용자 정보 조회(이름, 이메일)", description = "jwt 토큰을 통해 사용자 정보 조회")
+    public ApiResponse<MemberResponse> getUserInformation(@AuthenticationPrincipal AuthDetails authDetails) {
+        return ApiResponse.success(MemberResponse.of(authDetails.getMember()));
+    }
+
+    // 사용자가 연동한 account를 조회
+    @GetMapping("/accounts")
+    @Operation(summary = "사용자 연동 계정 조회", description = "사용자가 연동한 계정 조회")
+    public ApiResponse<?> getUserAccount(@AuthenticationPrincipal AuthDetails authDetails) {
+        return ApiResponse.success(accountService.getAccountsInfo(authDetails.getMember()));
+    }
+
+    @PatchMapping()
+    @Operation(summary = "사용자 이름 수정", description = "사용자 이름 수정")
+    public ApiResponse<?> updateUserName(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam("name") String name) {
+        return ApiResponse.success(memberService.updateMemberName(authDetails.getMember(), name));
+    }
+}

--- a/src/main/java/org/zapply/product/domain/user/controller/MemberController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/MemberController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.zapply.product.domain.user.dto.request.MemberRequest;
 import org.zapply.product.domain.user.dto.response.MemberResponse;
 import org.zapply.product.domain.user.service.AccountService;
+import org.zapply.product.domain.user.service.CredentialService;
 import org.zapply.product.domain.user.service.MemberService;
 import org.zapply.product.global.apiPayload.response.ApiResponse;
 import org.zapply.product.global.security.AuthDetails;
@@ -18,23 +20,40 @@ import org.zapply.product.global.security.AuthDetails;
 public class MemberController {
     private final AccountService accountService;
     private final MemberService memberService;
+    private final CredentialService credentialService;
 
     @GetMapping()
     @Operation(summary = "사용자 정보 조회(이름, 이메일)", description = "jwt 토큰을 통해 사용자 정보 조회")
-    public ApiResponse<MemberResponse> getUserInformation(@AuthenticationPrincipal AuthDetails authDetails) {
+    public ApiResponse<MemberResponse> getMemberInformation(@AuthenticationPrincipal AuthDetails authDetails) {
         return ApiResponse.success(MemberResponse.of(authDetails.getMember()));
     }
 
     // 사용자가 연동한 account를 조회
     @GetMapping("/accounts")
     @Operation(summary = "사용자 연동 계정 조회", description = "사용자가 연동한 계정 조회")
-    public ApiResponse<?> getUserAccount(@AuthenticationPrincipal AuthDetails authDetails) {
+    public ApiResponse<?> getMemberAccount(@AuthenticationPrincipal AuthDetails authDetails) {
         return ApiResponse.success(accountService.getAccountsInfo(authDetails.getMember()));
     }
 
-    @PatchMapping()
+    @PatchMapping("/name")
     @Operation(summary = "사용자 이름 수정", description = "사용자 이름 수정")
-    public ApiResponse<?> updateUserName(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam("name") String name) {
-        return ApiResponse.success(memberService.updateMemberName(authDetails.getMember(), name));
+    public ApiResponse<?> updateMemberName(@AuthenticationPrincipal AuthDetails authDetails,
+                                           @RequestBody MemberRequest memberRequest) {
+        return ApiResponse.success(memberService.updateMemberName(authDetails.getMember(), memberRequest.name()));
+    }
+
+    @PatchMapping("/password")
+    @Operation(summary = "사용자 비밀번호 수정", description = "사용자 비밀번호 수정")
+    public ApiResponse<?> updateMemberPassword(@AuthenticationPrincipal AuthDetails authDetails,
+                                               @RequestBody MemberRequest memberRequest) {
+        memberService.updateMemberPassword(authDetails.getMember(), memberRequest.password());
+        return ApiResponse.success("비밀번호 수정 성공");
+    }
+
+    @Operation(summary = "비밀번호 검증", description = "비밀번호 검증 true면 비밀번호 일치")
+    @PostMapping("/password/verify")
+    public ApiResponse<?> verifyPassword(@AuthenticationPrincipal AuthDetails authDetails,
+                                         @RequestBody MemberRequest memberRequest) {
+        return ApiResponse.success(credentialService.checkPassword(authDetails.getMember(), memberRequest.password()));
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/dto/request/MemberRequest.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/request/MemberRequest.java
@@ -1,8 +1,5 @@
 package org.zapply.product.domain.user.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberRequest(
         String name,
         String password

--- a/src/main/java/org/zapply/product/domain/user/dto/request/MemberRequest.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/request/MemberRequest.java
@@ -1,0 +1,10 @@
+package org.zapply.product.domain.user.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MemberRequest(
+        String name,
+        String password
+) {
+}

--- a/src/main/java/org/zapply/product/domain/user/dto/response/MemberResponse.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/response/MemberResponse.java
@@ -1,9 +1,12 @@
 package org.zapply.product.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import org.zapply.product.domain.user.entity.Member;
 
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
 public record MemberResponse(
         @Schema(description = "회원 ID", example = "1")

--- a/src/main/java/org/zapply/product/domain/user/entity/Credential.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Credential.java
@@ -22,4 +22,8 @@ public class Credential {
     public Credential(String hashedPassword) {
         this.password = hashedPassword;
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/org/zapply/product/domain/user/entity/Member.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Member.java
@@ -55,4 +55,8 @@ public class Member extends BaseTimeEntity {
         this.agreement = agreement;
         this.loginType = LoginType.DEFAULT;
     }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/org/zapply/product/domain/user/service/AccountService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AccountService.java
@@ -209,9 +209,6 @@ public class AccountService {
      */
     public AccountsInfoResponse getAccountsInfo(Member member) {
         List<Account> accounts = accountRepository.findAllByMember(member);
-        if (accounts.isEmpty()) {
-                throw new CoreException(GlobalErrorType.ACCOUNT_NOT_FOUND);
-        }
         return AccountsInfoResponse.of(
                 accounts.stream()
                         .map(AccountInfo::of)

--- a/src/main/java/org/zapply/product/domain/user/service/AuthService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/AuthService.java
@@ -22,7 +22,7 @@ import org.zapply.product.global.security.jwt.JwtProvider;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AuthService {
-    private final UserService userService;
+    private final MemberService memberService;
     private final CredentialService credentialService;
     private final JwtProvider jwtProvider;
     private final RedisClient redisClient;
@@ -40,7 +40,7 @@ public class AuthService {
     @Transactional
     public MemberResponse signUp(AuthRequest authRequest) {
         Credential credential = credentialService.createCredential(authRequest);
-        Member member = userService.createUser(credential, authRequest);
+        Member member = memberService.createMember(credential, authRequest);
 
         return MemberResponse.of(member);
     }
@@ -52,7 +52,7 @@ public class AuthService {
      */
     @Transactional
     public LoginResponse signIn(SignInRequest signInRequest) {
-        Member member = userService.getUserByEmail(signInRequest.email());
+        Member member = memberService.getMemberByEmail(signInRequest.email());
         credentialService.checkPassword(member, signInRequest.password());
         TokenResponse tokenResponse = jwtProvider.createToken(member);
         redisClient.setValue(member.getEmail(), tokenResponse.refreshToken(), refreshTokenExpirationTime);

--- a/src/main/java/org/zapply/product/domain/user/service/CredentialService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/CredentialService.java
@@ -36,12 +36,14 @@ public class CredentialService {
      * 비밀번호를 확인하는 메서드
      * @param member
      * @param password
+     * @return boolean
      */
-    public void checkPassword(Member member, String password) {
+    public boolean checkPassword(Member member, String password) {
         Credential credential = member.getCredential();
 
         if(!passwordEncoder.matches(password, credential.getPassword())) {
             throw new CoreException(GlobalErrorType.PASSWORD_MISMATCH);
         }
+        return true;
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/service/MemberService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/MemberService.java
@@ -12,7 +12,7 @@ import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 
 @Service
 @RequiredArgsConstructor
-public class UserService {
+public class MemberService {
 
     private final MemberRepository memberRepository;
 
@@ -22,8 +22,8 @@ public class UserService {
      * @param authRequest
      * @return Member
      */
-    public Member createUser(Credential credential, AuthRequest authRequest) {
-        memberRepository.findByEmailAndDeletedAtIsNull(authRequest.email()).ifPresent(existingUser -> {
+    public Member createMember(Credential credential, AuthRequest authRequest) {
+        memberRepository.findByEmailAndDeletedAtIsNull(authRequest.email()).ifPresent(existingMember -> {
            throw new CoreException(GlobalErrorType.MEMBER_ALREADY_EXISTS);
         });
         Member member = authRequest.toMember(credential);
@@ -35,7 +35,7 @@ public class UserService {
      * @param email
      * @return Member
      */
-    public Member getUserByEmail(String email) {
+    public Member getMemberByEmail(String email) {
         return memberRepository.findByEmailAndDeletedAtIsNull(email)
                 .orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
     }
@@ -46,7 +46,7 @@ public class UserService {
      * @param name
      * @return Member
      */
-    public MemberResponse updateUserName(Member member, String name) {
+    public MemberResponse updateMemberName(Member member, String name) {
         member.updateName(name);
         memberRepository.save(member);
         return MemberResponse.builder()

--- a/src/main/java/org/zapply/product/domain/user/service/MemberService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/MemberService.java
@@ -6,6 +6,7 @@ import org.zapply.product.domain.user.dto.request.AuthRequest;
 import org.zapply.product.domain.user.dto.response.MemberResponse;
 import org.zapply.product.domain.user.entity.Credential;
 import org.zapply.product.domain.user.entity.Member;
+import org.zapply.product.domain.user.repository.CredentialRepository;
 import org.zapply.product.domain.user.repository.MemberRepository;
 import org.zapply.product.global.apiPayload.exception.CoreException;
 import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
@@ -15,6 +16,7 @@ import org.zapply.product.global.apiPayload.exception.GlobalErrorType;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final CredentialRepository credentialRepository;
 
     /**
      * Credential을 생성하고 저장하는 메서드
@@ -44,7 +46,7 @@ public class MemberService {
      * 사용자 이름을 수정하는 메서드
      * @param member
      * @param name
-     * @return Member
+     * @return MemberResponse
      */
     public MemberResponse updateMemberName(Member member, String name) {
         member.updateName(name);
@@ -52,5 +54,16 @@ public class MemberService {
         return MemberResponse.builder()
                 .name(member.getName())
                 .build();
+    }
+
+    /**
+     * 사용자 비밀번호를 수정하는 메서드
+     * @param member
+     * @param password
+     * @return MemberResponse
+     */
+    public void updateMemberPassword(Member member, String password) {
+        member.getCredential().updatePassword(password);
+        credentialRepository.save(member.getCredential());
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/service/UserService.java
+++ b/src/main/java/org/zapply/product/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package org.zapply.product.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.zapply.product.domain.user.dto.request.AuthRequest;
+import org.zapply.product.domain.user.dto.response.MemberResponse;
 import org.zapply.product.domain.user.entity.Credential;
 import org.zapply.product.domain.user.entity.Member;
 import org.zapply.product.domain.user.repository.MemberRepository;
@@ -37,5 +38,19 @@ public class UserService {
     public Member getUserByEmail(String email) {
         return memberRepository.findByEmailAndDeletedAtIsNull(email)
                 .orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
+    }
+
+    /**
+     * 사용자 이름을 수정하는 메서드
+     * @param member
+     * @param name
+     * @return Member
+     */
+    public MemberResponse updateUserName(Member member, String name) {
+        member.updateName(name);
+        memberRepository.save(member);
+        return MemberResponse.builder()
+                .name(member.getName())
+                .build();
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #67 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 이름 수정
2. 비밀번호 수정
3. User -> Member로 네이밍 통일
4. 연동된 계정 찾기 에러 수정


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요

## 1&2
<img width="332" alt="스크린샷 2025-05-20 오후 7 13 02" src="https://github.com/user-attachments/assets/3a1f3b3d-10a2-4178-9885-e26e1bf82592" />

이름, 비밀번호를 받는 dto를 하나로 두고 non_null인 값만 받아오도록 수정했습니다!

## 3
저희가 사용자 엔티티를 Member로 네이밍을 하고 있어서 기존에 있던 모든 User 네이밍을 Member로 통일했습니다

## 4
<img width="535" alt="스크린샷 2025-05-20 오후 7 14 47" src="https://github.com/user-attachments/assets/93d4c6e9-3fee-4fca-a1c3-0f0daa7846a8" />

`getAccountInfo에 있던 if절 때문에 연동된 계정이 없을 때, 아예 exception이 터져서 로그인 시에 토큰이 발급되지 않는 문제가 생기는 것 같습니다.
기존에 성호님이 만들어두신 것중에 totalCount를 활용해서 프론트에서 연동된 계정이 없을 때의 플로우를 이어나가도 괜찮을 것 같아서 그렇게 수정했는데 어떤지 한번 봐주시면 감사하겠습니다!
<img width="192" alt="스크린샷 2025-05-20 오후 7 16 39" src="https://github.com/user-attachments/assets/8fe2b64f-e2e0-4857-b810-fa91a2aeeafd" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
