### PR TITLE
FIX: 페이스북 연동 콜백 주소에서 authdetail를 삭제한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -31,10 +31,9 @@ public class AccountController {
 
     @GetMapping("/facebook/link")
     @Operation(summary = "페이스북 액세스 토큰 발급", description = "페이스북 액세스 토큰 발급 (계정연동 API에서 연결되는 URL)")
-    public void linkFacebook(@RequestParam("code") String code,
-                             @AuthenticationPrincipal AuthDetails authDetails,
+    public void linkFacebook(@RequestParam("code") String code, @RequestParam(value="state") Long memberId,
                              HttpServletResponse response) throws IOException{
-        accountService.linkFacebook(code, authDetails.getMember().getId());
+        accountService.linkFacebook(code, memberId);
         String redirectUrl = "http://localhost:3000/facebook/callback";
         response.sendRedirect(redirectUrl);
     }


### PR DESCRIPTION
## 💡 관련 이슈
- #82 

## 📝 작업 내용
- 페이스북 콜백 주소에서 authdetail을 삭제합니다.