### PR TITLE
FEAT: 연동된 계정 조회 시 연동된 날짜를 반환한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/user/dto/response/AccountInfo.java
+++ b/src/main/java/org/zapply/product/domain/user/dto/response/AccountInfo.java
@@ -8,12 +8,14 @@ import org.zapply.product.global.clova.enuermerate.SNSType;
 @Builder
 public record AccountInfo(
         SNSType snsType,
-        String accountName
+        String accountName,
+        String linkedAt
 ) {
     public static AccountInfo of(Account account) {
         return AccountInfo.builder()
                 .snsType(account.getAccountType())
                 .accountName(account.getAccountName())
+                .linkedAt(account.getCreatedAt().toString())
                 .build();
     }
 }

--- a/src/main/java/org/zapply/product/domain/user/entity/Account.java
+++ b/src/main/java/org/zapply/product/domain/user/entity/Account.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.zapply.product.global.BaseTimeEntity;
 import org.zapply.product.global.clova.enuermerate.SNSType;
 
 import java.time.LocalDateTime;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Account {
+public class Account extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #85 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

<img width="441" alt="스크린샷 2025-05-21 오후 8 27 24" src="https://github.com/user-attachments/assets/ec6480c4-7fb8-43fd-9b06-7d36079fe4ef" />

- 연동된 날짜를 추가 반환할 수 있도록 account에 BaseTimeEntity를 추가했습니다! 삭제 로직은 지금 물리적 삭제로 되어 있는 것 같은데, 유효한 계정인지 나중에 계속 관리하려면 soft delete로 바꿔도 될 것 같다고 생각합니다! 근데 그럼 현재 짜여진 모든 쿼리문이나 삭제 로직이 바뀌어야 할 것 같아서 성호님 의견 남겨주시면 감사하겠습니다

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
