### PR TITLE
FEAT: Threads 게시글을 커서 기반 페이지네이션으로 조회한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
+++ b/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.zapply.product.domain.posting.dto.request.ThreadsPostingRequest;
+import org.zapply.product.domain.posting.dto.response.PostingDetailResponse;
 import org.zapply.product.domain.posting.dto.response.ThreadsInsightResponse;
 import org.zapply.product.domain.posting.dto.response.PostingInfoResponse;
 import org.zapply.product.domain.posting.service.PostingQueryService;
@@ -105,8 +106,8 @@ public class PostingController {
 
     @GetMapping("/threads/my-media")
     @Operation(summary = "SNS 게시물 리스트 조회하기", description = "SNS 게시물 리스트를 조회하는 메소드.")
-    public ApiResponse<?> getThreadsMedia(@RequestParam("snsType") SNSType snsType,
-                                                             @AuthenticationPrincipal AuthDetails authDetails) {
+    public ApiResponse<List<PostingDetailResponse>> getThreadsMedia(@RequestParam("snsType") SNSType snsType,
+                                                                    @AuthenticationPrincipal AuthDetails authDetails) {
         switch (snsType) {
             case THREADS:
                 return ApiResponse.success(postingQueryService.getAllThreadsMedia(authDetails.getMember()));
@@ -117,7 +118,7 @@ public class PostingController {
 
     @GetMapping("/threads/media")
     @Operation(summary = "SNS 단일 게시물 조회하기", description = "SNS 단일 게시물을 조회하는 메소드.")
-    public ApiResponse<?> getSingleThreadsMedia(@RequestParam("snsType") SNSType snsType,
+    public ApiResponse<PostingDetailResponse> getSingleThreadsMedia(@RequestParam("snsType") SNSType snsType,
                                                 @RequestParam("mediaId") String mediaId,
                                                 @AuthenticationPrincipal AuthDetails authDetails) {
         switch (snsType) {

--- a/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
+++ b/src/main/java/org/zapply/product/domain/posting/controller/PostingController.java
@@ -8,8 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.zapply.product.domain.posting.dto.request.ThreadsPostingRequest;
+import org.zapply.product.domain.posting.dto.response.CursorSlice;
 import org.zapply.product.domain.posting.dto.response.PostingDetailResponse;
-import org.zapply.product.domain.posting.dto.response.ThreadsInsightResponse;
+import org.zapply.product.global.snsClients.threads.ThreadsInsightResponse;
 import org.zapply.product.domain.posting.dto.response.PostingInfoResponse;
 import org.zapply.product.domain.posting.service.PostingQueryService;
 import org.zapply.product.domain.posting.service.PublishPostingService;
@@ -106,11 +107,13 @@ public class PostingController {
 
     @GetMapping("/threads/my-media")
     @Operation(summary = "SNS 게시물 리스트 조회하기", description = "SNS 게시물 리스트를 조회하는 메소드.")
-    public ApiResponse<List<PostingDetailResponse>> getThreadsMedia(@RequestParam("snsType") SNSType snsType,
-                                                                    @AuthenticationPrincipal AuthDetails authDetails) {
+    public ApiResponse<CursorSlice<PostingDetailResponse>> getThreadsMedia(@RequestParam(name = "cursor", required = false) String cursor,
+                                                                           @RequestParam(name = "size", defaultValue = "9") int size,
+                                                                           @RequestParam("snsType") SNSType snsType,
+                                                                           @AuthenticationPrincipal AuthDetails authDetails) {
         switch (snsType) {
             case THREADS:
-                return ApiResponse.success(postingQueryService.getAllThreadsMedia(authDetails.getMember()));
+                return ApiResponse.success(postingQueryService.getAllThreadsMedia(cursor, size, authDetails.getMember()));
             default:
                 return ApiResponse.success(null);
         }

--- a/src/main/java/org/zapply/product/domain/posting/dto/response/CursorSlice.java
+++ b/src/main/java/org/zapply/product/domain/posting/dto/response/CursorSlice.java
@@ -1,0 +1,9 @@
+package org.zapply.product.domain.posting.dto.response;
+
+import java.util.List;
+
+public record CursorSlice<T>(
+        List<T> content,
+        String nextCursor,
+        boolean hasNext
+) {}

--- a/src/main/java/org/zapply/product/domain/posting/dto/response/PostingDetailResponse.java
+++ b/src/main/java/org/zapply/product/domain/posting/dto/response/PostingDetailResponse.java
@@ -1,0 +1,42 @@
+package org.zapply.product.domain.posting.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PostingDetailResponse(
+        @Schema(description = "게시물 ID", example = "1234567890")
+        String postingId,
+
+        @Schema(description = "게시물 제목", example = "제목")
+        String postingTitle,
+
+        @Schema(description = "게시물 내용", example = "내용")
+        String postingContent,
+
+        @Schema(description = "발행 시간", example = "2023-10-01T12:00:00")
+        String publishedAt,
+
+        @Schema(description = "이미지 URL", example = "[https://zaply-landing.vercel.app/assets/images/ZaplyLanding.webp, https://zaply-landing.vercel.app/assets/images/ZaplyLanding.webp]")
+        List<String> postingImages
+) {
+    public static PostingDetailResponse of(
+            String postingId,
+            String postingTitle,
+            String postingContent,
+            String publishedAt,
+            List<String> postingImages
+    ) {
+        return PostingDetailResponse.builder()
+                .postingId(postingId)
+                .postingTitle(postingTitle)
+                .postingContent(postingContent)
+                .publishedAt(publishedAt)
+                .postingImages(postingImages)
+                .build();
+    }
+}

--- a/src/main/java/org/zapply/product/domain/posting/service/PostingQueryService.java
+++ b/src/main/java/org/zapply/product/domain/posting/service/PostingQueryService.java
@@ -3,11 +3,11 @@ package org.zapply.product.domain.posting.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.zapply.product.domain.posting.dto.response.CursorSlice;
 import org.zapply.product.domain.posting.dto.response.PostingDetailResponse;
 import org.zapply.product.domain.posting.dto.response.PostingInfoResponse;
 import org.zapply.product.domain.posting.entity.Posting;
 import org.zapply.product.domain.posting.repository.PostingRepository;
-import org.zapply.product.domain.project.entity.Project;
 import org.zapply.product.domain.project.repository.ProjectRepository;
 import org.zapply.product.domain.user.entity.Member;
 import org.zapply.product.global.apiPayload.exception.CoreException;
@@ -17,7 +17,9 @@ import org.zapply.product.global.clova.enuermerate.SNSType;
 import org.zapply.product.global.snsClients.threads.ThreadsMediaClient;
 import org.zapply.product.global.snsClients.threads.ThreadsMediaResponse;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -52,26 +54,53 @@ public class PostingQueryService {
     /**
      * 스레드 미디어 조회하기
      *
+     * @param cursor
+     * @param size
      * @param member
      * @param
      * @return 스레드 미디어 조회 결과
      */
-    public List<PostingDetailResponse> getAllThreadsMedia(Member member) {
+    public CursorSlice<PostingDetailResponse> getAllThreadsMedia(String cursor, int size, Member member) {
         // accessToken 가져오기
         String accessToken = accountService.getAccessToken(member, SNSType.THREADS);
-        // 스레드 API에 요청하여 미디어 데이터 가져오기
-        List<ThreadsMediaResponse.ThreadsMedia> threadsMedia = threadsMediaClient.getAllThreadsMedia(accessToken);
 
-        // 스레드 미디어를 PostingDetailResponse로 변환
-        return threadsMedia.stream()
+        // 커서 기반으로 페이징된 미디어 응답 가져오기
+        ThreadsMediaResponse response = threadsMediaClient.getAllThreadsMedia(
+                accessToken,
+                cursor,
+                size
+        );
+
+        List<PostingDetailResponse> content = response.data().stream()
+                .filter(media -> !media.is_quote_post())
+                .filter(media -> "IMAGE".equals(media.media_type()) ||
+                        "CAROUSEL_ALBUM".equals(media.media_type()) ||
+                        "TEXT_POST".equals(media.media_type()))
                 .map(media -> PostingDetailResponse.of(
                         media.id(),
                         "",
                         media.text(),
                         media.timestamp(),
-                        media.carousel_media_urls()
+                        switch (media.media_type()) {
+                            case "IMAGE" -> media.media_url() != null
+                                    ? List.of(media.media_url())
+                                    : Collections.emptyList();
+                            case "CAROUSEL_ALBUM" -> Optional.ofNullable(media.carousel_media_urls())
+                                    .orElse(Collections.emptyList());
+                            default -> Collections.emptyList();
+                        }
                 ))
                 .toList();
+
+        String nextCursor = response.paging() != null &&
+                response.paging().cursors() != null
+                ? response.paging().cursors().after()
+                : null;
+
+
+        boolean hasNext = nextCursor != null;
+
+        return new CursorSlice<>(content, nextCursor, hasNext);
     }
 
     /**

--- a/src/main/java/org/zapply/product/domain/posting/service/PostingQueryService.java
+++ b/src/main/java/org/zapply/product/domain/posting/service/PostingQueryService.java
@@ -3,6 +3,7 @@ package org.zapply.product.domain.posting.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.zapply.product.domain.posting.dto.response.PostingDetailResponse;
 import org.zapply.product.domain.posting.dto.response.PostingInfoResponse;
 import org.zapply.product.domain.posting.entity.Posting;
 import org.zapply.product.domain.posting.repository.PostingRepository;
@@ -55,11 +56,22 @@ public class PostingQueryService {
      * @param
      * @return 스레드 미디어 조회 결과
      */
-    public List<ThreadsMediaResponse.ThreadsMedia> getAllThreadsMedia( Member member) {
+    public List<PostingDetailResponse> getAllThreadsMedia(Member member) {
         // accessToken 가져오기
         String accessToken = accountService.getAccessToken(member, SNSType.THREADS);
         // 스레드 API에 요청하여 미디어 데이터 가져오기
-        return threadsMediaClient.getAllThreadsMedia(accessToken);
+        List<ThreadsMediaResponse.ThreadsMedia> threadsMedia = threadsMediaClient.getAllThreadsMedia(accessToken);
+
+        // 스레드 미디어를 PostingDetailResponse로 변환
+        return threadsMedia.stream()
+                .map(media -> PostingDetailResponse.of(
+                        media.id(),
+                        "",
+                        media.text(),
+                        media.timestamp(),
+                        media.carousel_media_urls()
+                ))
+                .toList();
     }
 
     /**
@@ -67,10 +79,19 @@ public class PostingQueryService {
      * @param member
      * @param mediaId
      */
-    public ThreadsMediaResponse.ThreadsMedia getSingleThreadsMedia(Member member, String mediaId) {
+    public PostingDetailResponse getSingleThreadsMedia(Member member, String mediaId) {
         // accessToken 가져오기
         String accessToken = accountService.getAccessToken(member, SNSType.THREADS);
         // 스레드 API에 요청하여 미디어 데이터 가져오기
-        return threadsMediaClient.getSingleThreadsMedia(accessToken, mediaId);
+        ThreadsMediaResponse.ThreadsMedia threadsMedia = threadsMediaClient.getSingleThreadsMedia(accessToken, mediaId);
+
+        // 스레드 미디어를 PostingDetailResponse로 변환
+        return PostingDetailResponse.of(
+                threadsMedia.id(),
+                "",
+                threadsMedia.text(),
+                threadsMedia.timestamp(),
+                threadsMedia.carousel_media_urls()
+        );
     }
 }

--- a/src/main/java/org/zapply/product/domain/posting/service/PublishPostingService.java
+++ b/src/main/java/org/zapply/product/domain/posting/service/PublishPostingService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zapply.product.domain.posting.dto.request.ThreadsPostingRequest;
-import org.zapply.product.domain.posting.dto.response.ThreadsPostingResponse;
+import org.zapply.product.global.snsClients.threads.ThreadsPostingResponse;
 import org.zapply.product.domain.posting.entity.Posting;
 import org.zapply.product.domain.posting.enumerate.MediaType;
 import org.zapply.product.domain.posting.enumerate.PostingState;

--- a/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsInsightClient.java
+++ b/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsInsightClient.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.zapply.product.domain.posting.dto.response.ThreadsInsightResponse;
 import org.zapply.product.domain.posting.entity.Posting;
 import org.zapply.product.domain.posting.repository.PostingRepository;
 import org.zapply.product.domain.user.entity.Member;

--- a/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsInsightResponse.java
+++ b/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsInsightResponse.java
@@ -1,4 +1,4 @@
-package org.zapply.product.domain.posting.dto.response;
+package org.zapply.product.global.snsClients.threads;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsPostingClient.java
+++ b/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsPostingClient.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.zapply.product.domain.posting.dto.request.ThreadsPostingRequest;
-import org.zapply.product.domain.posting.dto.response.ThreadsPostingResponse;
 import org.zapply.product.domain.posting.entity.Posting;
 import org.zapply.product.domain.posting.enumerate.PostingState;
 import org.zapply.product.domain.posting.repository.PostingRepository;

--- a/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsPostingResponse.java
+++ b/src/main/java/org/zapply/product/global/snsClients/threads/ThreadsPostingResponse.java
@@ -1,4 +1,4 @@
-package org.zapply.product.domain.posting.dto.response;
+package org.zapply.product.global.snsClients.threads;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #87
- #88 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="1462" alt="스크린샷 2025-05-23 오전 12 14 23" src="https://github.com/user-attachments/assets/65b0accb-823d-4816-8663-fd8bb6f0f7a8" />

- 첫번째 요청: cursor = null과 원하는 size값으로 요청하면 최신순으로 size 개수 만큼의 게시글만 조회하도록 하였습니다. 이때 나오는 nextCursor 값을 저장해두었다가 다음 요청시 cursor값에 넣어 요청하면 그 다음 게시글부터 조회할 수 있습니다.
- 두번째~ 요청: cursor=앞서 구한 cursor값과 원하는 size값으로 요청하면 최신순으로 size 개수 만큼의 게시글만 조회하도록 하였습니다.
- 마지막 요청 시 "hasNext": false 값을 가지면 더 이상 조회할 게시글이 없다는 의미입니다.

SliceImpl을 사용하려다가 다음 cursor값을 전달해주기 위해 Slice객체를 커스텀해주어야 할 것 같아서 CursorSlice를 생성했습니다!



## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
