### PR TITLE
FEAT: 링크드인, 트위터에 맞게 글의 분위기를 변경한다

### DIFF
--- a/src/main/java/org/zapply/product/domain/posting/service/ClovaService.java
+++ b/src/main/java/org/zapply/product/domain/posting/service/ClovaService.java
@@ -31,6 +31,9 @@ public class ClovaService {
     @Value("${cloud.ncp.clova.model-name}")
     private String modelName;
 
+    @Value("${prompt.title.system}")
+    private String titleSystemPrompt;
+
     @Value("${prompt.snstype.threads}")
     private String threadsPrompt;
 
@@ -40,8 +43,11 @@ public class ClovaService {
     @Value("${prompt.snstype.facebook}")
     private String facebookPrompt;
 
-    @Value("${prompt.title.system}")
-    private String titleSystemPrompt;
+    @Value("${prompt.snstype.linkedin}")
+    private String linkedinPrompt;
+
+    @Value("${prompt.snstype.twitter}")
+    private String twitterPrompt;
 
     private final ClovaAiClient clovaAiClient;
 
@@ -67,6 +73,8 @@ public class ClovaService {
                 case THREADS -> systemPrompt = threadsPrompt;
                 case INSTAGRAM -> systemPrompt = instagramPrompt;
                 case FACEBOOK -> systemPrompt = facebookPrompt;
+                case LINKEDIN -> systemPrompt = linkedinPrompt;
+                case TWITTER -> systemPrompt = twitterPrompt;
                 default -> throw new CoreException(GlobalErrorType.SNS_TYPE_NOT_FOUND);
             }
 

--- a/src/main/java/org/zapply/product/global/clova/enuermerate/SNSType.java
+++ b/src/main/java/org/zapply/product/global/clova/enuermerate/SNSType.java
@@ -14,7 +14,8 @@ public enum SNSType {
     THREADS("쓰레드"),
     INSTAGRAM("인스타그램"),
     FACEBOOK("페이스북"),
-    LINKEDIN("링크드인");
+    LINKEDIN("링크드인"),
+    TWITTER("트위터");
 
     private final String description;
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #115 

## 📝 작업 내용
- 링크드인, 트위터에 맞게 글의 분위기를 변환합니다.
