### PR TITLE
#117 Fix: Cors 헤더 붙여서 redirect

### DIFF
--- a/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
+++ b/src/main/java/org/zapply/product/domain/user/controller/AccountController.java
@@ -31,6 +31,8 @@ public class AccountController {
     public void linkFacebook(@RequestParam("code") String code, @RequestParam(value="state") Long memberId,
                              HttpServletResponse response) throws IOException{
         accountService.linkFacebook(code, memberId);
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
         String redirectUrl = "http://localhost:3000/facebook/callback";
         response.sendRedirect(redirectUrl);
     }


### PR DESCRIPTION
## 💡 관련 이슈
- #117 

## 📝 작업 내용
- Access to XMLHttpRequest at 'http://localhost:3000/facebook/callback' (redirected from 'https://api.zapply.site/v1/account/facebook/link?access_token=EAATzaPjtTXIBO2FiWHhfg01gSya0rNbFSzym1CkkBZBNORECi3cAO7mWwDlJ0ZBOwkOkEIHAOKqmttIItpkGSFZBmx63f70aDxbRYeNI5qVYlQzgBHYBZAxAXT92bXNjROTzTFdebmlb2cHOjkJ4f5qJkqvZBeXbHZBE3nZA3DZC4yS2YZA0IdGOKoQsK5cbIUYRrwfStUHPMkuuDFMX9ZBAZDZD') from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. 에러 해결 

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
